### PR TITLE
fix: production DB設定をDATABASE_URL明示参照に変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -81,9 +81,7 @@ test:
 production:
   primary: &primary_production
     <<: *default
-    database: tone_two_production
-    username: tone_two
-    password: <%= ENV["TONE_TWO_DATABASE_PASSWORD"] %>
+    url: <%= ENV["DATABASE_URL"] %>
   cache:
     <<: *primary_production
     database: tone_two_production_cache


### PR DESCRIPTION
## 目的
- Render本番環境でPostgreSQL接続先を環境変数ベースで明示し、接続設定ミスを減らす

## 結論
- `production.primary` の接続設定を `DATABASE_URL` 参照に統一した

## 変更点
- `config/database.yml` の `production.primary` から `database` `username` `password` を削除
- `config/database.yml` の `production.primary` に `url: <%= ENV["DATABASE_URL"] %>` を追加

## 手順
1. `config/database.yml` の `production` セクションを更新
2. `primary` の接続情報を `DATABASE_URL` に一本化

## 動作確認
- 未実施
- 本番デプロイログで `db:prepare` とWeb起動の成功を確認予定

## 参考資料（1次ソース）
- `config/database.yml`
- `docs/04_operations/deploy/2026-02-06-01-render-postgresql-setup.md`

## 関連Issue
WIP #8,#12
