### PR TITLE
docs: Issue #74のRender Health Check手順とHostヘッダ基礎理解メモを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,14 +83,13 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # 独自ドメイン導入時に、受け付ける Host を環境変数で明示する。
-  # TODO(MVP公開前): 本番ドメイン確定後に APP_ALLOWED_HOSTS を最終値へ更新する。
   allowed_hosts = ENV.fetch("APP_ALLOWED_HOSTS", "")
                      .split(",")
                      .map(&:strip)
                      .reject(&:empty?)
   config.hosts.concat(allowed_hosts) if allowed_hosts.any?
 
-  # デフォルトのヘルスチェックエンドポイントに対して、DNSリバインディング保護を無効にします。
+  # ヘルスチェックエンドポイントに対して、ホスト保護を無効にします。（死活監視用）
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # 仮公開中のみ有効化できるアクセス制限（/up は middleware 側で除外）。

--- a/docs/04_operations/monitoring/2026-02-08-01-render-health-check-issue-74-runbook.md
+++ b/docs/04_operations/monitoring/2026-02-08-01-render-health-check-issue-74-runbook.md
@@ -1,0 +1,67 @@
+# Issue #74 死活監視（Render Health Check）実施手順
+
+## 目的
+- サービスが停止していないことを、外部からのHTTP 200で継続確認できる状態にする。
+- ヘルスチェック失敗時に、Render上で異常検知できる運用手順を明文化する。
+
+## 結論
+- ToneTwo は Rails 標準の `/up` をヘルスチェックエンドポイントとして利用する。
+- Render Web Service の `Health Check Path` は `/up` を設定する。
+- 仮公開時の Basic 認証や Host 制限が有効でも、`/up` は疎通を維持する実装になっている。
+
+## 事前確認（根拠）
+### ローカル根拠
+- `config/routes.rb`
+  - `get "up" => "rails/health#show"` が定義済み。
+- `config/environments/production.rb`
+  - `config.host_authorization` で `/up` を除外。
+- `lib/preview_access_control.rb`
+  - Basic 認証適用中でも `HEALTHCHECK_PATH = "/up"` は除外。
+- `docs/04_operations/deploy/00_deploy_runbook.md`
+  - Render 側設定値として `Health Check Path: /up` を採用済み。
+- `README.md`
+  - 技術スタックで本番デプロイ先を Render として明記。
+
+### 公式一次ソース
+- Render Docs: Health Checks
+  - https://render.com/docs/health-checks
+- Rails Guides: Routing from the Outside In
+  - https://guides.rubyonrails.org/routing.html
+
+## Issue #74 対応方針（タスク対応）
+- `RenderのHealth Checkを設定`
+  - Render の Web Service に `/up` を設定する。
+- `/healthz などヘルスチェック用エンドポイントを用意`
+  - 現状は Rails 標準の `/up` を採用し、追加エンドポイントは作らない（運用を単純化）。
+- `監視が失敗した場合の挙動（再起動/通知）を確認`
+  - Render Dashboard の Health / Event / Logs で失敗検知が見えることを確認する。
+
+## 実作業手順
+1. ローカル実装を確認する。
+   - `bin/rails routes | rg 'rails_health_check|up'`
+   - `rg -n 'HEALTHCHECK_PATH|host_authorization|/up' config lib`
+2. Render Dashboard の対象 Web Service を開く。
+3. `Settings` で `Health Check Path` を `/up` に設定（未設定なら追加、相違があれば修正）。
+4. `Environment` で仮公開設定を使う場合は次を確認する。
+   - `PREVIEW_BASIC_AUTH_USER` / `PREVIEW_BASIC_AUTH_PASSWORD` が有効でも `/up` が除外される実装であること。
+5. デプロイ後に外形確認する。
+   - `curl -i https://www.tonetwo.net/up`
+   - 期待値: `HTTP/2 200`（または `HTTP/1.1 200`）
+6. Render Dashboard で監視状態を確認する。
+   - `Events` でデプロイ失敗や再起動ループの兆候が連発していないこと。
+   - `Logs`（Runtime）に継続的な異常（`failed` / `exception` / `timeout` など）が出ていないこと。
+
+## 障害時の確認手順（運用）
+1. `/up` が 200 で返るかをまず確認する。
+2. 200 でない場合は Render Runtime Logs を確認し、直近の例外を特定する。
+3. `APP_ALLOWED_HOSTS` の設定値と公開ドメインの不一致がないか確認する。
+4. 仮公開中は `PREVIEW_BASIC_AUTH_*` を見直し、`/up` 以外への制限が意図どおりか確認する。
+
+## 受け入れ条件（Definition of Done）
+- 外部から `https://www.tonetwo.net/up` にアクセスして 200 を定期確認できる。
+- Render Dashboard 上で Health Check 設定値（`/up`）と異常兆候（Events/Logs）を確認できる。
+
+## 参考
+- `docs/04_operations/monitoring/00_initial_monitoring.md`
+- `docs/04_operations/deploy/00_deploy_runbook.md`
+- `docs/04_operations/deploy/2026-02-06-02-mvp-release-deploy-checklist.md`

--- a/docs/04_operations/monitoring/2026-02-08-02-host-header-and-health-check-basics.md
+++ b/docs/04_operations/monitoring/2026-02-08-02-host-header-and-health-check-basics.md
@@ -1,0 +1,55 @@
+# Hostヘッダ偽装とヘルスチェックの基礎メモ
+
+## 目的
+- Issue #74 の作業で出てきた「Hostヘッダ」「DNSリバインディング保護」「/up」の関係を、後で見返せる形で残す。
+
+## 結論
+- `Host` は URL のドメイン部を示すHTTP情報で、クライアント側で任意値を送れる。
+- そのため、許可していないHostをアプリが受け入れると、URL生成やセキュリティ前提が崩れるリスクがある。
+- ToneTwo では Cloudflare と Rails (`config.hosts`) の二段で防御し、監視用の `/up` だけ例外で通している。
+
+## 用語
+- Host（ホスト）:
+  URL のドメイン部分（例: `www.tonetwo.net`）。
+- Hostヘッダ:
+  リクエストが「どのホスト宛てか」を示すHTTPヘッダ。
+- エンドポイント:
+  外部からアクセスするURLの受け口（例: `/up`）。
+- Basic認証:
+  ユーザー名/パスワードでアクセス制御する簡易認証方式。
+
+## なぜ Host 偽装が問題か
+1. アプリが正規ドメインを誤認する可能性がある。
+2. 絶対URL生成（例: メールリンク生成）で不正ドメインが混入するリスクがある。
+3. フィッシング導線や他の攻撃の足場になりやすくなる。
+
+## このリポジトリでの防御ポイント
+1. `config/environments/production.rb`
+   - `APP_ALLOWED_HOSTS` を `config.hosts` に反映し、許可Hostのみ受け付ける。
+   - `config.host_authorization = { exclude: ->(request) { request.path == "/up" } }` で `/up` のみ例外。
+2. `lib/preview_access_control.rb`
+   - `HEALTHCHECK_PATH = "/up"` をBasic認証対象から除外。
+   - 監視導線を塞がないため。
+3. Cloudflare
+   - 不正HostがCloudflare層で `403` になる場合がある（Rails到達前に遮断）。
+
+## 確認コマンド例
+```bash
+curl -i https://www.tonetwo.net/up
+curl -H 'Host: waruihost.tonetwo.net' https://www.tonetwo.net
+```
+
+## 2026-02-08 時点の確認結果
+- `/up` は `HTTP/2 200` を確認。
+- `Host: waruihost.tonetwo.net` を付けたアクセスは `403 Forbidden (cloudflare)` を確認。
+
+## 運用上のメモ
+- `/up` は「死活確認のため公開で到達できる」前提のエンドポイント。
+- `/up` には機密情報を出さない（現状はステータス確認用途の最小情報）。
+- Render監視確認は「`Health Check Path = /up`」「`/up` が200」「Events/Logsに異常連発がない」の3点で判定する。
+
+## 参考（ローカル）
+- `config/routes.rb`
+- `config/environments/production.rb`
+- `lib/preview_access_control.rb`
+- `docs/04_operations/monitoring/2026-02-08-01-render-health-check-issue-74-runbook.md`

--- a/lib/preview_access_control.rb
+++ b/lib/preview_access_control.rb
@@ -15,7 +15,7 @@ class PreviewAccessControl
 
   def call(env)
     req = ActionDispatch::Request.new(env)
-    # Render の監視導線は常に通す（ここを塞ぐとヘルスチェックが落ちる）。
+    # Render の監視導線は常に通す（ここを塞ぐとヘルスチェックが落ちる）
     return @app.call(env) if req.path == HEALTHCHECK_PATH
     # Basic認証が有効なときは、認証失敗なら 401 を返す。
     return unauthorized unless basic_auth_ok?(req)


### PR DESCRIPTION
## 目的
- Issue #74 の死活監視対応手順を運用ドキュメントとして明文化する
- Hostヘッダ偽装と `/up` 運用の基礎知識を再確認できる状態にする

## 結論
- Render Health Check は `/up` を基準に運用する方針を整理した
- Host保護と `/up` 例外の意図を、実装根拠とあわせて文書化した

## 変更点
- `docs/04_operations/monitoring/2026-02-08-01-render-health-check-issue-74-runbook.md` を追加
- `docs/04_operations/monitoring/2026-02-08-02-host-header-and-health-check-basics.md` を追加
- `config/environments/production.rb` のコメントを運用意図に沿って更新
- `lib/preview_access_control.rb` のコメント表現を微修正

## 手順
1. `/up` ルートと本番設定の実装根拠を確認した
2. Issue #74 向けの runbook を作成した
3. Hostヘッダ偽装と防御ポイントの基礎メモを作成した
4. 関連コメントを実装意図に合わせて整えた

## 動作確認
- `curl -i https://www.tonetwo.net/up` で `HTTP/2 200` を確認
- `curl -H 'Host: waruihost.tonetwo.net' https://www.tonetwo.net` で `403 Forbidden (cloudflare)` を確認

## 参考資料（1次ソース）
- https://render.com/docs/health-checks
- https://guides.rubyonrails.org/routing.html

## 関連Issue
Closes #74
