### PR TITLE
WIP: Rack::AttackのIP判定をCF-Connecting-IP優先に変更し本番検証メモを追加

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,15 +2,20 @@ class Rack::Attack
   # 本番のみ有効化（必要に応じて調整）
   Rack::Attack.enabled = Rails.env.production?
 
+  # Cloudflare経由の本番では、接続元プロキシIPではなく利用者IPを優先して使う。
+  def self.client_ip(req)
+    req.get_header("HTTP_CF_CONNECTING_IP").presence || req.ip
+  end
+
   # TODO(deploy後): Render/Cloudflare経由の本番で req.ip が期待どおりか検証し、必要ならしきい値/プロキシ設定を調整する
   # 1分あたりのリクエスト数をIPごとに制限（仮値）
   throttle("req/ip", limit: 120, period: 1.minute) do |req|
-    req.ip
+    client_ip(req)
   end
 
   # Basic認証ヘッダ付きリクエストだけを制限対象にする（仮公開向け）
   throttle("basic_auth/ip", limit: 20, period: 1.minute) do |req|
-    req.ip if req.path != "/up" && req.get_header("HTTP_AUTHORIZATION").present?
+    client_ip(req) if req.path != "/up" && req.get_header("HTTP_AUTHORIZATION").present?
   end
 
   # 429応答

--- a/docs/04_operations/monitoring/2026-02-09-03-rack-attack-req-ip-validation.md
+++ b/docs/04_operations/monitoring/2026-02-09-03-rack-attack-req-ip-validation.md
@@ -1,0 +1,73 @@
+# Rack::Attack `req.ip` 検証メモ（Render + Cloudflare）
+
+## 目的
+- 本番経路（Render + Cloudflare）で、Rack::Attack のIP判定キーが利用者IPを正しく見ているか確認する。
+- 誤ってCloudflare側IPでレート制限しないようにする。
+
+## 結論（2026-02-09時点）
+- 本番ログの `Started ... for ...` には `172.69.x.x` / `172.70.x.x` / `162.158.x.x` が出ており、利用者IPではなくCloudflare側IPを拾っている可能性が高い。
+- `config/initializers/rack_attack.rb` を修正し、Rack::Attack の判定キーを `CF-Connecting-IP` 優先に統一した。
+
+## 事実ベースの確認ログ
+- 検証アクセス:
+  - `GET /session/new?ipcheck=iptest-20260209-2355`
+- Renderログ:
+  - `Started GET "/session/new?ipcheck=iptest-20260209-2355" for 172.69.165.64 ...`
+  - フォント取得でも `162.158.162.136` / `172.69.165.54` が記録
+- 判定:
+  - Cloudflare配下のエッジIP帯が見えており、`req.ip` のみをキーにすると利用者単位の制限にならないリスクがある。
+
+## 実施したコード修正
+- 対象: `config/initializers/rack_attack.rb`
+- 変更内容:
+  - `Rack::Attack.client_ip(req)` を追加
+  - `req/ip` と `basic_auth/ip` の両throttleで `client_ip(req)` を利用
+  - `client_ip(req)` は `HTTP_CF_CONNECTING_IP` を優先し、未設定時は `req.ip` にフォールバック
+
+```ruby
+def self.client_ip(req)
+  req.get_header("HTTP_CF_CONNECTING_IP").presence || req.ip
+end
+```
+
+## 参考にした根拠
+### ローカル根拠
+- `Gemfile.lock`
+  - `rails (8.1.2)`
+  - `rack (3.2.4)`
+  - `rack-attack (6.8.0)`
+- `config/initializers/rack_attack.rb`
+  - throttleキーとして `req.ip` を使っていた実装を確認
+- `config/environments/production.rb`
+  - `trusted_proxies` の明示設定なし
+
+### 公式一次ソース
+- Rack::Attack README（`throttle` と instrumentation）
+  - https://github.com/rack/rack-attack/blob/6-stable/README.md
+- Rails `ActionDispatch::Request#ip` / `ActionDispatch::RemoteIp`
+  - https://github.com/rails/rails/tree/v8.1.2/actionpack/lib/action_dispatch
+
+## 次アクション
+1. 本修正をデプロイする。
+2. 同様に `?ipcheck=<token>` 付きでアクセスし、Renderログを確認する。
+3. 必要なら一時的に `request.ip` / `request.remote_ip` / `HTTP_CF_CONNECTING_IP` / `HTTP_X_FORWARDED_FOR` を同時ログ出力して最終判定する。
+4. IP判定が安定した後に、`limit` / `period` を実トラフィックに合わせて調整する。
+
+## 補足_1 CF-Connecting-IP を使う前提
+- クライアントは `CF-Connecting-IP` ヘッダを任意送信できるが、Cloudflare 経由時は Cloudflare が origin へ渡すヘッダを再構成する前提で運用する。
+- そのため、`HTTP_CF_CONNECTING_IP` を信頼する場合は「origin（`.onrender.com`）の直接到達を閉じる」ことが必須。
+- origin 直アクセスが可能だと、ヘッダ偽装でレート制限回避される余地が残る。
+- 実運用では「Cloudflare 経由のみ到達可能」であることを設定とログで証跡化しておく。
+- 参考（Cloudflare公式）:
+  - https://developers.cloudflare.com/fundamentals/reference/http-request-headers/
+
+## 補足_2 origin 直アクセス遮断の証跡
+- 実施日: 2026-02-09
+- 実行コマンド:
+  - `curl -i https://tonetwo.onrender.com/up`
+  - `curl -i https://tonetwo.onrender.com/session/new`
+- 結果:
+  - いずれも `HTTP/2 404`
+  - レスポンスヘッダに `x-render-routing: no-render-subdomain`
+- 判定:
+  - Renderサブドメイン（`.onrender.com`）は直接ルーティングされておらず、origin 直アクセスは閉じられている。


### PR DESCRIPTION
## 目的
- Render + Cloudflare 配下で Rack::Attack のIP判定を利用者IPベースに近づける。
- 本番検証の途中経過と今後の確認手順を記録する。

## 結論
- `CF-Connecting-IP` 優先の判定に変更した。
- 本番での最終検証としきい値最適化は未完了のため、PRはクローズしない。

## 変更点
- `config/initializers/rack_attack.rb`
  - `Rack::Attack.client_ip(req)` を追加
  - `req/ip` と `basic_auth/ip` の判定キーを `client_ip(req)` に統一
- `docs/04_operations/monitoring/2026-02-09-03-rack-attack-req-ip-validation.md`
  - 検証結果、前提条件、origin遮断証跡、次アクションを追記

## 手順
1. 本番ログで Cloudflare 側IP帯が出ることを確認。
2. `CF-Connecting-IP` 優先ロジックを実装。
3. 検証メモと運用前提を docs に記録。

## 動作確認
- 一部確認済み
- 未実施:
  - 本修正デプロイ後の再検証
  - 必要時の同時ログ出力による最終判定
  - `limit` / `period` の本番トラフィック調整

## 次アクション
1. 本修正をデプロイする。
2. `?ipcheck=<token>` 付きでアクセスし、Renderログを確認する。
3. 必要なら一時的に `request.ip` / `request.remote_ip` / `HTTP_CF_CONNECTING_IP` / `HTTP_X_FORWARDED_FOR` を同時ログ出力して最終判定する。
4. IP判定が安定した後に、`limit` / `period` を実トラフィックに合わせて調整する。

## 関連Issue
Refs #99
