### PR TITLE
fix: Rack::Attackの運用値確定と429発動テストを追加

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,14 +3,6 @@ class SessionsController < ApplicationController
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "ログイン試行が上限に達しました。3分ほど待ってから再度お試しください。" }
 
   def new
-    # 本番IP検証時のみ、Rack::Attackの判定キーを突き合わせる。
-    return unless params[:ipcheck].present?
-
-    Rails.logger.info(
-      "[ip-check] token=#{params[:ipcheck]} " \
-      "cf=#{request.get_header('HTTP_CF_CONNECTING_IP')} " \
-      "rack_attack_key=#{Rack::Attack.client_ip(request)}"
-    )
   end
 
   def create

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -9,7 +9,7 @@ class Rack::Attack
 
   # TODO(deploy後): Render/Cloudflare経由の本番で req.ip が期待どおりか検証し、必要ならしきい値/プロキシ設定を調整する
   # 1分あたりのリクエスト数をIPごとに制限（仮値）
-  throttle("req/ip", limit: 120, period: 1.minute) do |req|
+  throttle("req/ip", limit: 240, period: 1.minute) do |req|
     client_ip(req)
   end
 

--- a/docs/04_operations/monitoring/2026-02-09-03-rack-attack-req-ip-validation.md
+++ b/docs/04_operations/monitoring/2026-02-09-03-rack-attack-req-ip-validation.md
@@ -7,6 +7,7 @@
 ## 結論（2026-02-09時点）
 - 本番ログの `Started ... for ...` には `172.69.x.x` / `172.70.x.x` / `162.158.x.x` が出ており、利用者IPではなくCloudflare側IPを拾っている可能性が高い。
 - `config/initializers/rack_attack.rb` を修正し、Rack::Attack の判定キーを `CF-Connecting-IP` 優先に統一した。
+- `throttle("req/ip")` は試行値として `240/min` に設定した。運用中の429エラーの件数次第で調整。
 
 ## 事実ベースの確認ログ
 - 検証アクセス:
@@ -47,11 +48,13 @@ end
 - Rails `ActionDispatch::Request#ip` / `ActionDispatch::RemoteIp`
   - https://github.com/rails/rails/tree/v8.1.2/actionpack/lib/action_dispatch
 
-## 次アクション
-1. 本修正をデプロイする。
-2. 同様に `?ipcheck=<token>` 付きでアクセスし、Renderログを確認する。
-3. 必要なら一時的に `request.ip` / `request.remote_ip` / `HTTP_CF_CONNECTING_IP` / `HTTP_X_FORWARDED_FOR` を同時ログ出力して最終判定する。
-4. IP判定が安定した後に、`limit` / `period` を実トラフィックに合わせて調整する。
+## 手順
+1. `rack_attack.rb` で `Rack::Attack.client_ip(req)` に変更
+2. `SessionsController#new` に検証用の一時ログを追記する。
+3. 本番へデプロイする。
+4. `?ipcheck=<token>` 付きで `session/new` にアクセスする。
+5. 一時ログで `cf` と `rack_attack_key` と自分のIPアドレスが一致することを確認。
+6. 検証用の一時ログを削除する。
 
 ## 補足_1 CF-Connecting-IP を使う前提
 - クライアントは `CF-Connecting-IP` ヘッダを任意送信できるが、Cloudflare 経由時は Cloudflare が origin へ渡すヘッダを再構成する前提で運用する。
@@ -71,3 +74,8 @@ end
   - レスポンスヘッダに `x-render-routing: no-render-subdomain`
 - 判定:
   - Renderサブドメイン（`.onrender.com`）は直接ルーティングされておらず、origin 直アクセスは閉じられている。
+
+## 補足_3 ログイン試行制限の方針
+- `POST /session` は `SessionsController#create` の `rate_limit` を主担当とする。
+- 同一対象を `rack_attack.rb` 側でも重複して絞ると、誤遮断時の原因切り分けが難しくなるため原則避ける。
+- `rack_attack.rb` は全体防御（`req/ip`）と Basic認証向け（`basic_auth/ip`）を主目的に運用する。

--- a/test/integration/rack_attack_throttle_test.rb
+++ b/test/integration/rack_attack_throttle_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class RackAttackThrottleTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_enabled = Rack::Attack.enabled
+    @original_cache_store = Rack::Attack.cache.store
+
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    Rack::Attack.enabled = @original_enabled
+    Rack::Attack.cache.store = @original_cache_store
+  end
+
+  test "basic auth付きリクエストは上限超過で429を返す" do
+    headers = { "HTTP_AUTHORIZATION" => "Basic dGVzdDp0ZXN0" }
+
+    20.times do
+      get new_session_path, headers: headers
+      assert_response :success
+    end
+
+    get new_session_path, headers: headers
+    assert_response :too_many_requests
+    assert_equal "Too Many Requests", response.body
+  end
+
+  test "通常リクエストは上限超過で429を返す" do
+    240.times do
+      get new_session_path
+      assert_response :success
+    end
+
+    get new_session_path
+    assert_response :too_many_requests
+    assert_equal "Too Many Requests", response.body
+  end
+end


### PR DESCRIPTION
## 目的
- Render + Cloudflare 配下での Rack::Attack 運用値を確定する。
- 429発動を自動テストで検証可能にする。
- 検証内容と運用方針を docs に完了状態で記録する。

## 結論
- `req/ip` を `240/min` に変更し、MVP時点の運用値を仮確定した。
  - 実際運用してみないと正直よくわからんので、初期で429多発エラーでユーザー離脱を回避するために全体は緩和。
  - 運用開始してみて正常ユーザーから429エラーの報告が多発した場合に調整する。
  - 主機能実装後にエンドポイントごとにレート制限強化する。あとでissue立てる
- `basic_auth/ip` と `req/ip` の 429 発動テストを追加した。
- 検証用の一時ログは削除済み。
- docs は手順・結果・運用方針まで反映済み。

## 変更点
- `config/initializers/rack_attack.rb`
  - `throttle("req/ip")` を `120/min` から `240/min` に変更
- `app/controllers/sessions_controller.rb`
  - `ipcheck` 用の一時ログを削除
- `test/integration/rack_attack_throttle_test.rb`
  - `basic_auth/ip` の上限超過で 429 を返すテストを追加
  - `req/ip` の上限超過で 429 を返すテストを追加
- `docs/04_operations/monitoring/2026-02-09-03-rack-attack-req-ip-validation.md`
  - `240/min` 確定を追記
  - 手順を完了ベースに整理
  - ログイン試行制限の方針を追記

## 手順
1. `req/ip` のしきい値を `240/min` に変更した。
2. `basic_auth/ip` と `req/ip` の 429 テストを追加した。
3. 検証用一時ログを削除した。
4. docs に結果と運用方針を反映した。

## 動作確認
- `make test`
- 結果: `22 runs, 306 assertions, 0 failures, 0 errors, 7 skips`

## 参考資料（1次ソース）
- https://github.com/rack/rack-attack/blob/6-stable/README.md
- https://github.com/rails/rails/tree/v8.1.2/actionpack/lib/action_dispatch
- https://developers.cloudflare.com/fundamentals/reference/http-request-headers/

## 関連Issue
Closes #99
