### PR TITLE
fix: ユーザー登録後のフラッシュメッセージ機能を削除

### DIFF
--- a/app/controllers/sign_ups_controller.rb
+++ b/app/controllers/sign_ups_controller.rb
@@ -12,7 +12,7 @@ class SignUpsController < ApplicationController
 
     if @user.save
       start_new_session_for(@user)
-      redirect_to root_path, notice: "ユーザー登録が完了しました。"
+      redirect_to root_path
     else
       flash.now[:alert] = "入力内容を確認してください。"
       render :new, status: :unprocessable_entity


### PR DESCRIPTION
本番環境での手動テスト時にフラッシュメッセージがリダイレクト先（root)で出現せず、
ログアウト後に別ページ表示時に出現するバグを発見。

本来、リダイレクト先での表示の設定が必要だが、
リダイレクト動作自体でユーザーには登録完了がわかり、
フラッシュメッセージの表示自体が冗長のため該当のフラッシュメッセージ機能を削除。