### PR TITLE
feat: マッチング除外語テーブルを追加

### DIFF
--- a/app/models/matching_exclusion_term.rb
+++ b/app/models/matching_exclusion_term.rb
@@ -1,0 +1,6 @@
+class MatchingExclusionTerm < ApplicationRecord
+  # 正規化して、不要な差分登録を防ぐ。
+  normalizes :term, with: ->(value) { value&.strip }
+
+  validates :term, presence: true, uniqueness: true
+end

--- a/app/services/posts/similar_posts_query.rb
+++ b/app/services/posts/similar_posts_query.rb
@@ -25,7 +25,7 @@ module Posts
         end
 
       # 除外語（私、ここ、今日など）
-      excluded_terms = MatchingExcludedTerm.enabled.select(:term)
+      excluded_terms = MatchingExclusionTerm.select(:term)
 
       term_ids =
         PostTerm

--- a/db/migrate/20260213093000_create_matching_exclusion_terms.rb
+++ b/db/migrate/20260213093000_create_matching_exclusion_terms.rb
@@ -1,0 +1,18 @@
+class CreateMatchingExclusionTerms < ActiveRecord::Migration[8.1]
+  def change
+    create_table :matching_exclusion_terms do |t|
+      t.string :term, null: false
+
+      t.timestamps
+    end
+
+    add_check_constraint :matching_exclusion_terms,
+      "char_length(trim(both from term)) > 0",
+      name: "chk_matching_exclusion_terms_term_not_blank"
+
+    add_index :matching_exclusion_terms,
+      :term,
+      unique: true,
+      name: "index_matching_exclusion_terms_on_term"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_13_093000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_090000) do
     t.index ["term"], name: "index_filter_terms_on_term", unique: true
     t.check_constraint "action::text = ANY (ARRAY['prohibit'::character varying::text, 'support'::character varying::text])", name: "chk_filter_terms_action_valid"
     t.check_constraint "char_length(TRIM(BOTH FROM term)) > 0", name: "chk_filter_terms_term_not_blank"
+  end
+
+  create_table "matching_exclusion_terms", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "term", null: false
+    t.datetime "updated_at", null: false
+    t.index ["term"], name: "index_matching_exclusion_terms_on_term", unique: true
+    t.check_constraint "char_length(TRIM(BOTH FROM term)) > 0", name: "chk_matching_exclusion_terms_term_not_blank"
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,12 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
+# Load shared seed files tracked in Git.
+load Rails.root.join("db/seeds/matching_exclusion_terms.rb")
+
 # Load local-only seed files (e.g. sensitive moderation terms) if present.
-Dir[Rails.root.join("db/seeds/*.local.rb")].sort.each do |seed_file|
-  load seed_file
+unless Rails.env.production?
+  Dir[Rails.root.join("db/seeds/*.local.rb")].sort.each do |seed_file|
+    load seed_file
+  end
 end

--- a/db/seeds/matching_exclusion_terms.rb
+++ b/db/seeds/matching_exclusion_terms.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# おすすめ表示のマッチングで情報量が低い一般語を除外する。
+matching_exclusion_terms = %w[
+  私
+  わたし
+  ワタシ
+  俺
+  おれ
+  オレ
+  僕
+  ぼく
+  ボク
+  自分
+  じぶん
+  ジブン
+  ここ
+  ココ
+  そこ
+  ソコ
+  あそこ
+  アソコ
+  こちら
+  コチラ
+  そちら
+  ソチラ
+  これ
+  コレ
+  それ
+  ソレ
+  あれ
+  アレ
+  どれ
+  ドレ
+  こと
+  もの
+  とき
+  ため
+  よう
+]
+
+# 重複排除/べき等性対応
+matching_exclusion_terms.uniq.each do |term|
+  record = MatchingExclusionTerm.find_or_initialize_by(term: term)
+  record.save! if record.new_record?
+end

--- a/docs/04_operations/moderation/2026-02-13-01-matching-exclusion-terms-mvp-ops.md
+++ b/docs/04_operations/moderation/2026-02-13-01-matching-exclusion-terms-mvp-ops.md
@@ -1,0 +1,63 @@
+# MatchingExclusionTerms運用方針（MVP）
+
+## 目的
+- おすすめ表示のマッチングで情報量が低い一般語を除外し、ノイズ一致を減らす。
+
+## 要件（確定）
+- テーブル: `matching_exclusion_terms`
+- カラム: `term` のみ（`enabled` は持たない/使わない語はシンプルに削除する）
+- 制約:
+  - `term` は `NOT NULL`
+  - `term` は trim 後に空文字不可（CHECK制約）
+  - `term` は UNIQUE
+- 無効化方法:
+  - 使わなくなった語は「削除」で対応する。
+
+## 現在の実装
+- モデル:
+  - `app/models/matching_exclusion_term.rb`
+  - `normalizes :term` で前後空白のみ除去
+  - `validates :term, presence: true, uniqueness: true`
+- マッチング参照:
+  - `app/services/posts/similar_posts_query.rb`
+  - `MatchingExclusionTerm.select(:term)` を使い、存在語をそのまま除外
+- DB定義:
+  - `db/migrate/20260213093000_create_matching_exclusion_terms.rb`
+  - `db/schema.rb`
+
+## 運用方針（MVP）
+- シードは公開管理とする（Git管理）。
+  - ファイル: `db/seeds/matching_exclusion_terms.rb`
+- 追加・更新は seed 編集で対応し、管理画面実装後に管理画面運用へ移行する。
+- 表記ゆれ対応は seed 側で持つ。
+  - 例: 漢字/ひらがな/カタカナを必要に応じて並記
+- 時系列語（`今日` など）は文脈差に効くため、現時点の除外語から外す。
+
+## 反映手順
+1. 語彙を更新する
+- 編集対象: `db/seeds/matching_exclusion_terms.rb`
+
+2. 開発環境へ投入する
+- `make db-seed`
+- または `bin/rails db:seed`
+
+3. DBを作り直して投入する
+- `make db-reset-seed`
+
+4. 反映確認
+- 件数確認:
+  - `bin/rails runner "puts MatchingExclusionTerm.count"`
+- サンプル確認:
+  - `bin/rails runner "puts MatchingExclusionTerm.order(:term).limit(30).pluck(:term)"`
+
+## 注意点
+- 現在の除外一致は「完全一致」。
+- 形態素解析の名詞抽出は表層形ベースのため、必要な揺れは seed に追加する。
+
+## 参考
+- `db/seeds/matching_exclusion_terms.rb`
+- `db/seeds.rb`
+- `app/models/matching_exclusion_term.rb`
+- `app/services/posts/similar_posts_query.rb`
+- `db/migrate/20260213093000_create_matching_exclusion_terms.rb`
+- `Makefile`

--- a/test/models/matching_exclusion_term_test.rb
+++ b/test/models/matching_exclusion_term_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class MatchingExclusionTermTest < ActiveSupport::TestCase
+  setup do
+    MatchingExclusionTerm.delete_all
+  end
+
+  test "termの前後空白を除去して保存する" do
+    record = MatchingExclusionTerm.create!(term: "  今日  ")
+
+    assert_equal "今日", record.term
+  end
+
+  test "termが空文字のときは無効" do
+    record = MatchingExclusionTerm.new(term: "   ")
+
+    assert_not record.valid?
+    assert_includes record.errors[:term], "can't be blank"
+  end
+
+  test "termは一意である" do
+    MatchingExclusionTerm.create!(term: "ここ")
+    duplicate = MatchingExclusionTerm.new(term: "ここ")
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:term], "has already been taken"
+  end
+end


### PR DESCRIPTION
## 目的
- Issue #23 の対応として、レコメンドのマッチング除外語をDBで管理できるようにする
- MVP向けに、除外語の更新フローをシード運用で確立する

## 結論
- `matching_exclusion_terms` を追加し、`SimilarPostsQuery` で存在語をそのまま除外する実装に統一した
- 除外語は公開シードで管理し、`production` では `.local.rb` を読まない安全ガードを入れた
- 運用方針ドキュメントを新規作成した

## 変更点
- DB追加
  - `db/migrate/20260213093000_create_matching_exclusion_terms.rb`
  - `term` に `NOT NULL`、空文字防止CHECK、UNIQUE index を追加
  - `db/schema.rb` 更新
- モデル/クエリ
  - `app/models/matching_exclusion_term.rb` 追加
  - `app/services/posts/similar_posts_query.rb` の参照を `MatchingExclusionTerm.select(:term)` に変更
- シード運用
  - `db/seeds/matching_exclusion_terms.rb` 追加
  - `db/seeds.rb` を明示ロード化し、`production` で `.local.rb` を読み込まないよう変更
- ドキュメント
  - `docs/04_operations/moderation/2026-02-13-01-matching-exclusion-terms-mvp-ops.md` 追加
- テスト
  - `test/models/matching_exclusion_term_test.rb` 追加

## 動作確認
- `db/seeds/matching_exclusion_terms.rb` を作成
- `bin/rails db:seed` 実行
- `MatchingExclusionTerm.count` が `35` 件であることを確認

## 参考資料（1次ソース）
- `docs/02_architecture/er.md`
- `app/services/posts/similar_posts_query.rb`
- `db/migrate/20260213093000_create_matching_exclusion_terms.rb`
- `db/seeds/matching_exclusion_terms.rb`

## 関連Issue
Closes #23
