### PR TITLE
chore: bootsnapを1.23.0へ更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.0.1)
     bindex (0.8.1)
-    bootsnap (1.22.0)
+    bootsnap (1.23.0)
       msgpack (~> 1.2)
     brakeman (8.0.2)
       racc


### PR DESCRIPTION
## 目的
- Dependabotで提案された `bootsnap` の更新を取り込み、依存関係を最新化する

## 結論
- `bundle update bootsnap` し、`bootsnap` を `1.22.0` から `1.23.0` に更新した

## 変更点
- `Gemfile.lock`
  - `bootsnap (1.22.0)` -> `bootsnap (1.23.0)`

## 動作確認
- `make test-all` を実行し成功
- 内訳
  - RuboCop: 成功
  - Brakeman: 成功
  - importmap audit: 成功
  - Minitest: `57 runs, 678 assertions, 0 failures, 0 errors, 7 skips`

## 参考資料（1次ソース）
- https://github.com/rails/bootsnap/releases/tag/v1.23.0
- https://github.com/rails/bootsnap/compare/v1.22.0...v1.23.0

## 関連Issue
Closes #123
