### PR TITLE
chore: Dockerfile修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ RUN bundle install && \
 
 # npm設定（本番 build 用）
 COPY package.json package-lock.json ./
-RUN npm ci && npm cache clean --force
+RUN npm ci && rm -rf /root/.npm
 
 # Railsアプリのコードすべて（一個目の./ホスト側のカレントディレクトリ)を
 # コンテナ内(二個目の./コンテナ内のカレントディレクトリ)にコピー = コンテナに載せる


### PR DESCRIPTION
デプロイがキャッシュ落ちで失敗した際に、
ログ調査でnpm コマンドが --force 付きで実行されている警告を発見。

依存関係の整合性チェックや保護動作を無視して進める可能性があるため
--forceを削除した。

（ビルド自体はノーキャッシュで再ビルド完了済み）