### PR TITLE
投稿フォームで140文字超過時の警告表示を追加

### DIFF
--- a/app/javascript/controllers/post_body_length_controller.js
+++ b/app/javascript/controllers/post_body_length_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["input", "message"]
+  static targets = ["input", "message", "alert"]
   static values = { limit: { type: Number, default: 140 } }
 
   // 初期表示時に警告表示を同期する
@@ -15,5 +15,15 @@ export default class extends Controller {
     const isOver = value.length > this.limitValue
     this.messageTarget.textContent = isOver ? `${this.limitValue}文字を超えています` : "\u00A0"
     this.messageTarget.classList.toggle("invisible", !isOver)
+    if (!isOver) this.alertTarget.classList.add("hidden")
+  }
+
+  // 超過時の送信を防ぎ、フォーム上部にエラーを表示する
+  guardSubmit(event) {
+    const value = this.inputTarget.value || ""
+    if (value.length <= this.limitValue) return
+
+    event.preventDefault()
+    this.alertTarget.classList.remove("hidden")
   }
 }

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -8,7 +8,18 @@
       </div>
     <% end %>
 
-    <%= form_with model: @post, url: posts_path, class: "space-y-5", data: { controller: "post-body-length", post_body_length_limit_value: 140 } do |form| %>
+    <%= form_with model: @post,
+                  url: posts_path,
+                  class: "space-y-5",
+                  data: {
+                    controller: "post-body-length",
+                    post_body_length_limit_value: 140,
+                    action: "submit->post-body-length#guardSubmit"
+                  } do |form| %>
+      <div class="alert alert-error mb-6 hidden" data-post-body-length-target="alert">
+        <span>140字を超えているため投稿できません</span>
+      </div>
+
       <fieldset class="fieldset">
         <legend class="fieldset-legend text-base font-semibold">本文</legend>
         <%= form.text_area :body,


### PR DESCRIPTION
## 目的
- 新規投稿フォームで、本文が140文字を超えたことを入力中にユーザーへ明示する

## 結論
- Stimulusコントローラを追加し、本文入力時に140文字超過メッセージを表示するようにした
- 非表示時も警告行の高さを確保し、表示切替時に投稿ボタンが動かないようにした

## 変更点
- `app/javascript/controllers/post_body_length_controller.js` を新規追加
- `app/views/posts/new.html.erb` に `data-controller="post-body-length"` を追加
- 本文 `textarea` に `input->post-body-length#check` を追加
- 警告文要素を追加し、`invisible` と `min-h-6` でレイアウトを固定
- `maxlength: 140` を削除し、超過入力時に警告表示のみ行う構成へ変更

## 動作確認
- ローカルブラウザ上で動作確認

## 参考資料（1次ソース）
- `app/javascript/controllers/post_body_length_controller.js`
- `app/views/posts/new.html.erb`

## 関連Issue
Closes #18
