### PR TITLE
docs/fix: タイムライン無限スクロールの描画構成を簡素化し運用ドキュメントを整備

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -207,4 +207,129 @@
     transform: translateY(0);
   }
 
+  /* 投稿一覧/詳細で共通利用する表示スタイル */
+  .tt-post-row {
+    border-bottom: 1px solid #EEF2F7;
+    padding: 2rem;
+  }
+
+  .tt-post-row:last-child {
+    border-bottom: 0;
+  }
+
+  .tt-post-row-link {
+    transition: background-color 150ms ease;
+  }
+
+  .tt-post-row-link:hover {
+    background-color: #F9FBFD;
+  }
+
+  .tt-post-meta {
+    text-align: right;
+    font-size: 0.75rem;
+    letter-spacing: 0.025em;
+    color: #8896B2;
+  }
+
+  .tt-post-body {
+    margin-top: 0.75rem;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+    color: #3A486D;
+  }
+
+  /* タイムライン画面のタブ/投稿フォームの共通スタイル */
+  .tt-tab-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    border-radius: 1rem;
+    background-color: rgba(255, 255, 255, 0.65);
+    padding: 0.25rem;
+    backdrop-filter: blur(4px);
+  }
+
+  .tt-tab-base {
+    display: flex;
+    height: 3rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 150ms ease, color 150ms ease;
+  }
+
+  .tt-tab-active {
+    background-color: #68CBCE;
+    color: #ffffff !important;
+    box-shadow: 0 1.5px 0 rgba(0, 0, 0, 0.16);
+  }
+
+  .tt-tab-inactive {
+    background-color: transparent;
+    color: #858EA6;
+  }
+
+  .tt-tab-inactive:hover {
+    background-color: #eef7f8;
+  }
+
+  .tt-post-form-card {
+    border-radius: 0.25rem;
+    background-color: #ffffff;
+    padding: 0.75rem;
+  }
+
+  .tt-post-textarea {
+    min-height: 0 !important;
+    width: 100%;
+    resize: none;
+    overflow: hidden;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+    color: #3A486D;
+  }
+
+  .tt-post-submit {
+    display: inline-flex;
+    height: 2rem;
+    min-height: 0;
+    align-items: center;
+    border: 0;
+    border-radius: 9999px;
+    background-color: #68CBCE;
+    padding: 0 2rem;
+    font-size: 1rem;
+    font-weight: 400;
+    color: #ffffff;
+  }
+
+  .tt-post-submit:hover {
+    background-color: #58bcc0;
+  }
+
+  .tt-form-error-inline {
+    min-height: 1.5rem;
+    font-size: 0.875rem;
+    color: #E86572;
+  }
+
+  .tt-empty-state {
+    border-radius: 0.5rem;
+    background-color: #ffffff;
+    padding: 2.5rem;
+    text-align: center;
+    font-size: 1.125rem;
+    color: #8392AE;
+  }
+
 }

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -3,14 +3,15 @@ class TimelineController < ApplicationController
   PER_PAGE = 20
 
   def index
-    # 全体タブの表示状態をビューへ渡す。
+    # 「今は全体タブがアクティブ」というビュー向けの状態フラグ
     @active_tab = :all
     # タイムラインに必要な投稿データを取得してインスタンス変数へセットする。
     load_feed!
 
-    # lazy frame からの追い読み時は一覧差分だけ返し、画面全体は再描画しない。
+    # _next_frame.html.erb からのturbo_frameでリクエストされてるかチェック
     return unless turbo_frame_request?
 
+    # 次ページのturbo_frameリクエストの場合は、部分テンプレートを返す。
     render partial: "timeline/feed_chunk",
            locals: { posts: @posts, has_next: @has_next, next_path: @next_path }
   end
@@ -32,19 +33,30 @@ class TimelineController < ApplicationController
   private
 
   def load_feed!
-    # 投稿フォームは初回HTMLでのみ。無限スクロールのレスポンスには含めない。
+    # 投稿フォームは初回のみ。無限スクロールのレスポンスには含めない。
     @post = Post.new unless turbo_frame_request?
 
-    # created_at降順 + id降順で、同時刻投稿でも順序がぶれないようにする。
+    # app/services/posts/cursor_paginator.rb を呼び出して、投稿のページネーションを行う。
+    # created_at降順 + id降順を固定。同時刻投稿でも順序がぶれないようにする。
     result = Posts::CursorPaginator.call(
+      # タイムライン全体の投稿を対象にする（実際のpostが入っているわけではなく、クエリのための範囲指定の指示だけがはいっているイメージ。なので、処理重くならない）
       scope: Post.order(created_at: :desc, id: :desc),
+      # 次ページの取得に必要なカーソル時刻を前回のリクエストから取得する（初回はnil）
       before_created_at: params[:before_created_at],
+      # 次ページの取得に必要なカーソルIDを前回のリクエストから取得する（初回はnil）
       before_id: params[:before_id],
+      # PRE_PAGE件ずつ取得する（現在は20件）
       per_page: PER_PAGE
-    )
+      )
 
-    @has_next = result.has_next
+    # Result: Posts::CursorPaginator.call の返り値
+    # result.posts: 今回表示する1ページ分の投稿
+    # result.has_next: 次ページがあるかのフラグ
+    # result.last_post: 次ページカーソル生成の基準になる末尾投稿
+
+    # 取得した投稿データをインスタンス変数へセットする。
     @posts = result.posts
+    @has_next = result.has_next
     @next_path = build_next_path(result.last_post) if @has_next && result.last_post.present?
   end
 

--- a/app/services/posts/cursor_paginator.rb
+++ b/app/services/posts/cursor_paginator.rb
@@ -2,30 +2,39 @@
 
 module Posts
   class CursorPaginator
+    # Result = Struct.new(...):　型定義
     # posts: 今回表示する1ページ分
-    # has_next: 次ページがあるか
-    # last_post: 次ページカーソル生成の基準になる末尾投稿
+    # has_next: 次ページがあるかのフラグ
+    # last_post: 次ページのカーソル生成の基準になる末尾投稿
+    # keyword_init: true キーワード引数で渡すためのオプション
     Result = Struct.new(:posts, :has_next, :last_post, keyword_init: true)
 
     def self.call(scope:, before_created_at:, before_id:, per_page:)
       # 次のページの取得に必要なカーソル時刻とIDをリクエストから取得する。
+      # 初回はnil
       cursor_time = parse_cursor_time(before_created_at)
       cursor_id = before_id.to_i if before_id.present?
 
+      # カーソルが有効な場合は、カーソルより古い投稿に絞り込む。
+      # 比較が重いので、 created_at と id の複合インデックスを追加
       if cursor_time.present? && cursor_id.present?
         scope = scope.where(
           "posts.created_at < ? OR (posts.created_at = ? AND posts.id < ?)",
-          cursor_time, # カーソル時刻より古い投稿
-          cursor_time, # 同時刻投稿を対象に含める比較用
-          cursor_id    # 同時刻内ではIDが小さい(=より古い側)投稿
+          # posts.created_at < cursor_time : カーソル時刻より古い投稿
+          cursor_time,
+          # OR (posts.created_at = cursor_time AND posts.id < cursor_id) : 同時刻内ではIDが小さい(=より古い側)投稿
+          cursor_time, cursor_id
         )
       end
 
-      # 1件多く取得して「次ページあり」を判定し、表示はper_page件に絞る。
+      # recordsはPostの実データ。スコープから20+1件取得して配列に格納。
       records = scope.limit(per_page + 1).to_a
+      # postsは20件のみの実データ。（表示の1ページ分）
       posts = records.first(per_page)
+      # has_nextはrecordsに21件あるか判定し、あれば次ページ有のフラグを立てる。
       has_next = records.size > per_page
 
+      # Result.new(...): Result = Struct.newで定義した型に合わせて返り値を生成する。
       Result.new(posts: posts, has_next: has_next, last_post: posts.last)
     end
 
@@ -34,6 +43,8 @@ module Posts
       return nil if value.blank?
 
       Time.zone.parse(value)
+    # URLパラメータが不正な日時文字列だった場合は例外
+    # 例外が発生したらカーソル無効として扱い、最初のページを返すために nil を返す。
     rescue ArgumentError
       nil
     end

--- a/app/views/my/posts/_feed_chunk.html.erb
+++ b/app/views/my/posts/_feed_chunk.html.erb
@@ -1,3 +1,4 @@
 <%= turbo_frame_tag "my_posts_next" do %>
-  <%= render "my/posts/feed_page", posts: posts, has_next: has_next, next_path: next_path %>
+  <%= render "my/posts/post_rows", posts: posts %>
+  <%= render "my/posts/next_frame", has_next: has_next, next_path: next_path %>
 <% end %>

--- a/app/views/my/posts/_feed_page.html.erb
+++ b/app/views/my/posts/_feed_page.html.erb
@@ -1,2 +1,0 @@
-<%= render "my/posts/post_rows", posts: posts %>
-<%= render "my/posts/next_frame", has_next: has_next, next_path: next_path %>

--- a/app/views/my/posts/_post_rows.html.erb
+++ b/app/views/my/posts/_post_rows.html.erb
@@ -1,10 +1,10 @@
 <% posts.each do |post| %>
   <% posted_at = post.created_at.in_time_zone("Asia/Tokyo") %>
   <% posted_at_label = posted_at.today? ? posted_at.strftime("%H:%M Today") : posted_at.strftime("%Y/%m/%d %H:%M") %>
-  <%= link_to my_post_path(post), class: "group flex items-end gap-4 border-b border-[#EEF2F7] px-8 py-8 last:border-b-0 transition-colors hover:bg-[#F9FBFD]", aria: { label: "投稿詳細へ" } do %>
+  <%= link_to my_post_path(post), class: "tt-post-row tt-post-row-link group flex items-end gap-4", aria: { label: "投稿詳細へ" } do %>
     <div class="min-w-0 flex-1">
-      <p class="text-right text-xs tracking-wide text-[#8896B2]"><%= posted_at_label %></p>
-      <p class="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-[#3A486D]"><%= post.body.to_s.strip %></p>
+      <p class="tt-post-meta"><%= posted_at_label %></p>
+      <p class="tt-post-body"><%= post.body.to_s.strip %></p>
     </div>
 
     <span class="shrink-0">

--- a/app/views/my/posts/index.html.erb
+++ b/app/views/my/posts/index.html.erb
@@ -4,10 +4,11 @@
 
     <% if @posts.any? %>
       <div class="tt-shadow-min overflow-hidden rounded-lg bg-white">
-        <%= render "my/posts/feed_page", posts: @posts, has_next: @has_next, next_path: @next_path %>
+        <%= render "my/posts/post_rows", posts: @posts %>
+        <%= render "my/posts/next_frame", has_next: @has_next, next_path: @next_path %>
       </div>
     <% else %>
-      <div class="tt-shadow-min rounded-lg bg-white p-10 text-center text-lg text-[#8392AE]">
+      <div class="tt-shadow-min tt-empty-state">
         投稿はまだありません。
       </div>
     <% end %>

--- a/app/views/my/posts/show.html.erb
+++ b/app/views/my/posts/show.html.erb
@@ -5,8 +5,8 @@
     <h1 class="text-3xl font-bold mb-8 text-[#3A486D]">自分の投稿詳細</h1>
 
     <article class="tt-shadow-min rounded-lg bg-white px-8 py-8">
-      <p class="text-right text-xs tracking-wide text-[#8896B2]"><%= posted_at_label %></p>
-      <p class="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-[#3A486D]"><%= @post.body.to_s.strip %></p>
+      <p class="tt-post-meta"><%= posted_at_label %></p>
+      <p class="tt-post-body"><%= @post.body.to_s.strip %></p>
     </article>
 
     <div class="mt-8 flex justify-end">

--- a/app/views/timeline/_feed_chunk.html.erb
+++ b/app/views/timeline/_feed_chunk.html.erb
@@ -1,3 +1,7 @@
+<%# タグがturbo_frame時に、投稿行と次ページトリガーだけ返す %>
+<%# つまり、2回目以降にpost_rowsでポストを描写し、次の読み込みのnext_frameを呼び出す %>
+
 <%= turbo_frame_tag "timeline_next" do %>
-  <%= render "timeline/feed_page", posts: posts, has_next: has_next, next_path: next_path %>
+  <%= render "timeline/post_rows", posts: posts %>
+  <%= render "timeline/next_frame", has_next: has_next, next_path: next_path %>
 <% end %>

--- a/app/views/timeline/_feed_page.html.erb
+++ b/app/views/timeline/_feed_page.html.erb
@@ -1,3 +1,0 @@
-<%# 投稿を出す + 次ページトリガーを置く　%>
-<%= render "timeline/post_rows", posts: posts %>
-<%= render "timeline/next_frame", has_next: has_next, next_path: next_path %>

--- a/app/views/timeline/_next_frame.html.erb
+++ b/app/views/timeline/_next_frame.html.erb
@@ -1,4 +1,11 @@
 <%# 次ページを自動で読み込む仕掛け　%>
+
+<%# フラグがある場合のみ、以下のHTMLが生成される
+<turbo-frame id="timeline_next" src="...next_path..." loading="lazy"></turbo-frame>　%>
+
 <% if has_next && next_path.present? %>
   <%= turbo_frame_tag "timeline_next", src: next_path, loading: :lazy %>
 <% end %>
+
+<%# loading: :lazy
+ページ初期表示のタイミングではすぐ読み込まず、Frameが画面内に見えた時点で読み込む　%>

--- a/app/views/timeline/_post_rows.html.erb
+++ b/app/views/timeline/_post_rows.html.erb
@@ -1,15 +1,19 @@
 <% posts.each do |post| %>
+  <%# 表示はJST基準。今日の投稿だけ時刻のみを出す。 %>
   <% posted_at = post.created_at.in_time_zone("Asia/Tokyo") %>
   <% posted_at_label = posted_at.today? ? posted_at.strftime("%H:%M Today") : posted_at.strftime("%Y/%m/%d %H:%M") %>
+
+  <%# 自分の投稿だけ詳細ページへ遷移できるようにする。 %>
   <% if post.user_id == Current.user.id %>
-    <%= link_to my_post_path(post), class: "group block border-b border-[#EEF2F7] px-8 py-8 last:border-b-0 transition-colors hover:bg-[#F9FBFD]", aria: { label: "自分の投稿詳細へ" } do %>
-      <p class="text-right text-xs tracking-wide text-[#8896B2]"><%= posted_at_label %></p>
-      <p class="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-[#3A486D]"><%= post.body.to_s.strip %></p>
+    <%= link_to my_post_path(post), class: "tt-post-row tt-post-row-link group block", aria: { label: "自分の投稿詳細へ" } do %>
+      <p class="tt-post-meta"><%= posted_at_label %></p>
+      <p class="tt-post-body"><%= post.body.to_s.strip %></p>
     <% end %>
   <% else %>
-    <article class="border-b border-[#EEF2F7] px-8 py-8 last:border-b-0">
-      <p class="text-right text-xs tracking-wide text-[#8896B2]"><%= posted_at_label %></p>
-      <p class="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-[#3A486D]"><%= post.body.to_s.strip %></p>
+    <%# 他ユーザー投稿は閲覧のみ（リンクなし）。 %>
+    <article class="tt-post-row">
+      <p class="tt-post-meta"><%= posted_at_label %></p>
+      <p class="tt-post-body"><%= post.body.to_s.strip %></p>
     </article>
   <% end %>
 <% end %>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -1,20 +1,20 @@
 <main class="min-h-screen">
   <section class="mx-auto max-w-xl px-8 py-12">
     <div class="mb-5">
-      <div role="tablist" class="grid grid-cols-2 gap-1 rounded-2xl border border-white/70 bg-white/65 p-1 backdrop-blur-sm">
+      <div role="tablist" class="tt-tab-list">
         <%= link_to "全体",
                     timeline_path,
                     role: "tab",
                     class: [
-                      "tt-tab-link flex h-12 items-center justify-center rounded-xl text-base font-semibold no-underline transition",
-                      (@active_tab == :all ? "bg-[#68CBCE] !text-[#FFF] shadow-[0_1.5px_0_rgba(0,0,0,0.16)]" : "bg-transparent text-[#858EA6] hover:bg-[#eef7f8]")
+                      "tt-tab-link tt-tab-base",
+                      (@active_tab == :all ? "tt-tab-active" : "tt-tab-inactive")
                     ] %>
 
         <%= link_to similar_timeline_path,
                     role: "tab",
                     class: [
-                      "tt-tab-link flex h-12 items-center justify-center gap-2 rounded-xl text-base font-semibold no-underline transition",
-                      (@active_tab == :similar ? "bg-[#68CBCE] !text-[#FFF] shadow-[0_1.5px_0_rgba(0,0,0,0.16)]" : "bg-transparent text-[#858EA6] hover:bg-[#eef7f8]")
+                      "tt-tab-link tt-tab-base gap-2",
+                      (@active_tab == :similar ? "tt-tab-active" : "tt-tab-inactive")
                     ] do %>
           <span>おすすめ</span>
           <% help_icon = (@active_tab == :similar ? "icons/help_white.svg" : "icons/help.svg") %>
@@ -41,11 +41,11 @@
                   } do |form| %>
       <div class="hidden" data-post-body-length-target="alert"></div>
 
-      <div class="rounded bg-white p-3">
+      <div class="tt-post-form-card">
         <%= form.text_area :body,
                            required: true,
                            rows: 1,
-                           class: "textarea-plain !min-h-0 w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-sm leading-6 text-[#3A486D]",
+                           class: "textarea-plain tt-post-textarea",
                            placeholder: "今どんな感じ？",
                            data: {
                              post_body_length_target: "input",
@@ -53,19 +53,20 @@
                              action: "input->post-body-length#check input->auto-grow-textarea#resize"
                            } %>
         <div class="mt-2 flex justify-end">
-          <%= form.submit "投稿", class: "inline-flex h-8 min-h-0 items-center rounded-full border-0 bg-[#68CBCE] px-8 text-base font-normal text-white hover:bg-[#58bcc0]" %>
+          <%= form.submit "投稿", class: "tt-post-submit" %>
         </div>
       </div>
 
-      <p class="min-h-6 text-sm text-[#E86572] invisible" data-post-body-length-target="message" aria-live="polite"></p>
+      <p class="tt-form-error-inline invisible" data-post-body-length-target="message" aria-live="polite"></p>
     <% end %>
 
     <% if @posts.any? %>
       <div class="tt-shadow-min mt-6 overflow-hidden rounded-lg bg-white">
-        <%= render "timeline/feed_page", posts: @posts, has_next: @has_next, next_path: @next_path %>
+        <%= render "timeline/post_rows", posts: @posts %>
+        <%= render "timeline/next_frame", has_next: @has_next, next_path: @next_path %>
       </div>
     <% else %>
-      <div class="tt-shadow-min mt-6 rounded-lg bg-white p-10 text-center text-lg text-[#8392AE]">
+      <div class="tt-shadow-min tt-empty-state mt-6">
         投稿はまだありません。
       </div>
     <% end %>

--- a/db/migrate/20260216074136_add_created_at_id_index_to_posts.rb
+++ b/db/migrate/20260216074136_add_created_at_id_index_to_posts.rb
@@ -1,0 +1,5 @@
+class AddCreatedAtIdIndexToPosts < ActiveRecord::Migration[8.1]
+  def change
+    add_index :posts, %i[created_at id], name: "index_posts_on_created_at_and_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_14_145300) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_16_074136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,11 +50,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_14_145300) do
     t.float "sentiment_score"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["created_at", "id"], name: "index_posts_on_created_at_and_id"
     t.index ["user_id", "created_at"], name: "index_posts_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_posts_on_user_id"
     t.check_constraint "char_length(TRIM(BOTH FROM body)) > 0", name: "chk_posts_body_not_blank"
     t.check_constraint "char_length(body) <= 140", name: "chk_posts_body_max_140"
-    t.check_constraint "sentiment_label IS NULL OR (sentiment_label::text = ANY (ARRAY['pos'::character varying, 'neg'::character varying]::text[]))", name: "chk_posts_sentiment_label_valid"
+    t.check_constraint "sentiment_label IS NULL OR (sentiment_label::text = ANY (ARRAY['pos'::character varying::text, 'neg'::character varying::text]))", name: "chk_posts_sentiment_label_valid"
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/docs/03_engineering/frontend/infinite_scroll_logic.md
+++ b/docs/03_engineering/frontend/infinite_scroll_logic.md
@@ -1,0 +1,116 @@
+# 無限スクロール実装メモ（Timeline / My Posts）
+
+このドキュメントは、現行コードの無限スクロール実装をロジックを理解するために整理したものです。
+
+## 対象ファイル
+- `app/controllers/timeline_controller.rb`
+- `app/controllers/my/posts_controller.rb`
+- `app/services/posts/cursor_paginator.rb`
+- `app/views/timeline/index.html.erb`
+- `app/views/timeline/_feed_chunk.html.erb`
+- `app/views/timeline/_next_frame.html.erb`
+- `app/views/timeline/_post_rows.html.erb`
+- `app/views/my/posts/index.html.erb`
+- `app/views/my/posts/_feed_chunk.html.erb`
+- `app/views/my/posts/_next_frame.html.erb`
+- `app/views/my/posts/_post_rows.html.erb`
+
+## 全体像
+- 初回表示: サーバーが投稿を `20件 + 判定用1件` 取得してHTMLを返す。
+- 次ページ判定: 21件目があれば `has_next = true`。
+- 読み込みトリガー: 画面下部の `turbo_frame_tag(..., src: next_path, loading: :lazy)` がビューポートに入ると自動リクエスト。
+- 続きのレスポンス: Turbo Frame リクエスト時は一覧差分（chunk）だけ返す。
+- ページング方式: `before_created_at` と `before_id` を使うカーソル方式（offsetではない）。
+
+## 1. 初回表示の流れ
+1. `timeline#index` / `my/posts#index` で `load_feed!` を呼ぶ。
+2. `Posts::CursorPaginator.call(...)` に `before_created_at` と `before_id` なしで渡す。
+3. 新しい順（`created_at DESC, id DESC`）で最大21件を取得。
+4. 先頭20件を表示用 `@posts`、21件目の有無を `@has_next` にセット。
+5. `@has_next` が true のときだけ `@next_path` を生成。
+6. ビューが `_post_rows` + `_next_frame` を描画。
+
+## 2. 次ページ読み込みの流れ
+1. `next_frame` 部分テンプレートが以下を出す。
+   - `timeline`: `<turbo-frame id="timeline_next" ...>`
+   - `my_posts`: `<turbo-frame id="my_posts_next" ...>`
+2. その frame が見えると、Turbo が`src=next_path` に自動GET。
+3. コントローラは `turbo_frame_request?` を検知。
+4. フルHTMLではなく `feed_chunk` 部分テンプレートだけ返す。
+5. Turbo は `id` (id="timeline_next" or id="my_posts_next") で置換対象を判別
+6. chunk 内で `post_rows` と `next_frame` を再描画する。
+7. `has_next` が false になった時点で `next_frame` が消え、そこで停止。
+
+## 3. カーソル条件（重複・取りこぼし対策）
+`Posts::CursorPaginator` のWHERE条件は次の通り。
+
+```sql
+posts.created_at < :cursor_time
+OR (posts.created_at = :cursor_time AND posts.id < :cursor_id)
+```
+
+意図:
+- `created_at` だけだと同時刻投稿の順序がぶれる可能性がある。
+- 同時刻は「ほぼ起きない」前提にせず、連続INSERT・精度丸め・テスト投入などで実際に起きうる前提で設計する。
+- `id` を第2キーにして「同時刻ならIDが小さい方が古い」と定義し、安定して次ページを切る。
+
+## 4. `+1件取得` の意味
+- `limit(per_page + 1)`（この実装では 21件）で取得。
+- 表示は先頭 `per_page`（20件）だけ使う。
+- 余った1件の存在だけで「次ページあり」を判定。
+
+これで `COUNT(*)` を毎回打たずに済む。
+
+## 5. タイムラインと自分投稿の違い
+共通:
+- `Posts::CursorPaginator` を使う。
+- 1ページ20件。
+- Turbo Frame の lazy 読み込み構造。
+
+相違:
+- `timeline` は `Post` 全体を対象。
+- `my/posts` は `Current.user.posts` のみ対象。
+- frame ID と部分テンプレートのパスが異なる。
+
+## 6. URLパラメータの意味
+- `before_created_at`: 現在表示ページ末尾投稿の `created_at`（ISO8601）
+- `before_id`: 現在表示ページ末尾投稿の `id`
+
+次ページURL生成時に「今回の末尾」を渡すことで、その投稿より古い範囲だけを取る。
+
+※ ISO8601: 日時を文字列で表す国際標準形式。例: `2026-02-16T16:30:45.123456+09:00`
+
+## 7. つまずきやすい点
+- `turbo_frame_request?` の分岐を壊すと、lazy読込時にページ全体HTMLを返して崩れる。
+- 並び順（`created_at DESC, id DESC`）とカーソル条件はセット。片方だけ変えると重複/欠落が出やすい。
+- `before_created_at` のパース失敗時はカーソル無効扱いになる（初回相当の挙動）。
+
+## 8. 不正カーソル時の方針（現状）
+- 方針: 不正な `before_created_at` は `nil` 扱いにして処理継続する（`500` は返さない）。
+- 実装位置: `app/services/posts/cursor_paginator.rb` の `parse_cursor_time`。
+- 理由:
+  - カーソル値は認可・機密に直結する情報ではなく、主影響はページング表示の乱れにとどまる。
+  - 入力異常で `500` にすると可用性を下げるため、フォールバック継続のメリットが大きい。
+  - 攻撃価値が低く、現時点で `400` 厳格化の優先度は高くない。
+- 補足: 不正入力の増加を監視したくなった段階で、警告ログ追加や `400` 化を検討する。
+
+## 9. テストで担保していること
+- lazy frame が出ること
+  - `test/integration/timeline_flow_test.rb`
+  - `test/integration/my_posts_flow_test.rb`
+- cursor付きアクセスで「古い投稿のみ返る」こと
+  - 同上ファイルの `cursor付きアクセス` テスト
+
+## 10. インデックス追加（2026-02-16）
+- 追加内容: `posts(created_at, id)` の複合インデックスを追加。
+  - migration: `db/migrate/20260216074136_add_created_at_id_index_to_posts.rb`
+  - index名: `index_posts_on_created_at_and_id`
+- 追加理由:
+  - 全体タイムラインは `created_at DESC, id DESC` で並び替え、同じキーでカーソル条件（`created_at` と `id`）を使ってページングする。
+  - データ件数が増えるほど、並び替えと範囲抽出のコストが増えるため、対応する複合インデックスで負荷増を抑える。
+- 想定効果:
+  - 無限スクロール時の「次ページ取得クエリ」の安定化（遅延悪化の抑制）。
+  - 特に全体TL（`Post` 全体対象）の読み込み性能に効く。
+
+---
+この文書は「今の実装」を説明するメモです。アルゴリズム変更時（例: おすすめTLの本実装）には更新してください。


### PR DESCRIPTION
## 目的
- タイムライン無限スクロールの描画構成を理解しやすくし、保守性を上げる
- 投稿表示スタイルの重複を減らす
- カーソルページングのクエリ性能劣化を抑える
- 実装ロジックを docs に明文化する

## 結論
- `feed_page` 経由をやめ、`post_rows` と `next_frame` を直接描画する構成に統一した
- 投稿一覧まわりのクラスを `tt-*` コンポーネントとして共通化した
- `posts(created_at, id)` 複合インデックスを追加した
- 無限スクロールの処理フローと設計意図を docs 化した

## 変更点
- `timeline` / `my/posts` の `index` と `feed_chunk` で直接描画へ統一
- 未使用になった `_feed_page.html.erb` を削除
- 投稿メタ情報・本文・行スタイル、タブ/投稿フォームのスタイルを `application.tailwind.css` のコンポーネントへ移設
- `db/migrate/20260216074136_add_created_at_id_index_to_posts.rb` を追加
- `db/schema.rb` へ `index_posts_on_created_at_and_id` を反映
- `docs/03_engineering/frontend/infinite_scroll_logic.md` を追加し、  
  カーソル方式、Turbo Frame 差し替え、`id` 併用理由、ISO8601、インデックス追加理由を記載

## 動作確認
- `make css-build` 実行で Tailwind ビルド反映を確認
- `make db-migrate` 実行でインデックス作成を確認
- ローカルテスト完了

## 参考資料（1次ソース）
- `app/controllers/timeline_controller.rb`
- `app/services/posts/cursor_paginator.rb`
- `app/views/timeline/_next_frame.html.erb`
- `db/migrate/20260216074136_add_created_at_id_index_to_posts.rb`
- `docs/03_engineering/frontend/infinite_scroll_logic.md`

## 関連Issue
Closes #19
