### PR TITLE
feat: bump-rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.5)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
     rack-session (2.1.1)


### PR DESCRIPTION
## 目的
- Dependabot Alert「Rack has a Directory Traversal via Rack:Directory」への対応として、`rack` を修正版へ更新する

## 結論
- `rack` を `3.2.4` から `3.2.5` へ更新した

## 変更点
- `Gemfile.lock`
- `rack (3.2.4)` → `rack (3.2.5)`

## 動作確認
- `bundle exec ruby -e 'require "rack"; puts Rack.release'` が `3.2.5` を出力
- `make test-all` 成功
- RuboCop / Brakeman / importmap audit / test が通過

## 参考資料（1次ソース）
- https://github.com/advisories/GHSA-mxw3-3hh2-x2mh
- https://github.com/rack/rack/blob/main/CHANGELOG.md

## 関連Issue
Closes #139