### PR TITLE
chore: nokogiriを1.19.1に更新して脆弱性対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.5)
-    nokogiri (1.19.0-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (1.27.0)


### PR DESCRIPTION
## 目的
- Dependabotで報告された nokogiri の脆弱性対応を行う

## 結論
- `nokogiri` を `1.19.0` から `1.19.1` へ更新した

## 変更点
- `Gemfile.lock` の `nokogiri` バージョンを更新
  - `1.19.0-x86_64-linux-gnu` -> `1.19.1-x86_64-linux-gnu`

## 動作確認
- テスト一式が通過

## 参考資料（1次ソース）
- GitHub Advisory Database: GHSA-wx95-c6cv-8532
- nokogiri security advisory: GHSA-wx95-c6cv-8532

## 関連Issue
Closes #147