### PR TITLE
feat: systemテスト基盤を整備し主要導線E2Eと認証ガードを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,14 @@ jobs:
               - "db/**"
               - "lib/**"
               - "test/**"
+              - "Dockerfile.dev"
+              - "docker-compose.dev.yml"
+              - "docker-compose.test.yml"
               - "Gemfile"
               - "Gemfile.lock"
               - "Rakefile"
+              - "Makefile"
+              - ".github/workflows/ci.yml"
 
   # ----------------------------
   # Ruby静的チェック（Brakeman + Rubocop）
@@ -103,68 +108,21 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
 
-    # job内で使うサービスコンテナ（テスト用DBなど）を起動
-    services:
-      postgres:
-        # postgres公式イメージでDBを起動
-        image: postgres
-        # DBユーザー/パスワード（テスト用）
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        # runner（Ubuntu）側の localhost:5432 にポート公開
-        ports:
-          - 5432:5432
-        # DB起動完了を待つためのヘルスチェック（pg_isready が通るまでリトライ）
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      # Redisも使う場合のテンプレ（今は無効）
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
-      # OSパッケージをインストール
-      # - build-essential: ネイティブ拡張のビルド（ffi等）に必要になることがある
-      # - git: bundlerがgitソースのgemを取る場合に必要
-      # - libpq-dev: PostgreSQL用ネイティブ拡張（pg等）ビルド用ヘッダ
-      # - libyaml-dev: psych（YAML）まわりで必要になることがある
-      # - pkg-config: ネイティブ依存の検出補助
-      # - mecab/libmecab-dev/mecab-ipadic-utf8: natto が MeCab（libmecab.so）を使うために必要
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev pkg-config mecab libmecab-dev mecab-ipadic-utf8
-
       # ソース取得
       - name: Checkout code
         uses: actions/checkout@v6
 
-      # Rubyセットアップ + bundlerキャッシュ
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: .ruby-version
-          bundler-cache: true
-
-      # Tailwind CSS をビルド（レイアウトで tailwind.css を参照するため）
-      - name: Build CSS assets
-        run: |
-          mkdir -p app/assets/builds
-          npm ci
-          npm run build:css
-
-      # テスト実行
-      # - RAILS_ENV=test: テスト環境で起動
-      # - DATABASE_URL: services.postgres が localhost:5432 で待っているのでそこに接続
-      # - db:test:prepare: テストDB準備
-      # - test: unit/integration等のテスト
-      # - --exclude: Rack::Attack系はローカル実行に寄せる
+      # Dockerfile.dev + docker-compose.test.yml を使って、ローカルと同じ経路で実行する
       - name: Run tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
-        run: |
-          bin/rails db:test:prepare
-          bin/rails test --exclude '/RackAttackThrottleTest/'
+        run: make test
+
+      # system test 失敗時の画面を保全して調査しやすくする
+      - name: Upload test screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-screenshots
+          path: tmp/screenshots/failures_*.png
+          retention-days: 1
+          if-no-files-found: ignore

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -50,6 +50,15 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     # 鍵（GPG）を扱う。ダウンロードした鍵を apt が使える形に変換するため。
     gnupg \
     # ====================
+    # system test（Selenium + Headless Chrome）関連
+    # ====================
+    # headlessブラウザ本体
+    chromium \
+    # Chromiumに対応するWebDriver
+    chromium-driver \
+    # 日本語フォント（スクリーンショットの文字化けを避ける）
+    fonts-noto-cjk \
+    # ====================
     #  MeCab（本体 + 補助コマンド + 開発ヘッダ + IPA辞書）
     # ====================
     mecab \
@@ -86,6 +95,9 @@ RUN mkdir -p /etc/apt/keyrings \
   && apt-get update -qq && apt-get install -y --no-install-recommends nodejs \
   # rm -rf /var/lib/apt/lists/*：aptのキャッシュ削除 → 軽量化
   && rm -rf /var/lib/apt/lists/*
+
+# system test実行時に必要なバイナリが存在することをビルド時に確認する
+RUN chromium --version && chromedriver --version
 
 # ====================
 #  NEologdのインストール

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@
 | シークレット検知（CI） | GitGuardian |
 | 静的解析 | RuboCop |
 | セキュリティ静的解析 | Brakeman |
-| テスト | MVPでは最小限（手動確認＋重要箇所のみMinitestのrequest/integration test） |
+| テスト | Minitest（request/integration主軸 + 重要導線のみsystem test） |
 | バージョン管理 | GitHub |
 | インフラ補助 | Docker, GitHub Actions |
 
@@ -416,9 +416,10 @@
 ---
 
 ###  テスト
-- **MVPでは最小限（手動確認＋重要箇所のみMinitestのrequest/integration test）**
-    - MVP段階では開発スピードを優先し、基本は手動確認で動作を担保する
-    - ただし、壊れると致命的な導線（例：ログイン、投稿、リプライ、ミュート、退会など）は Minitest の `request/integration test` を最小限だけ用意し、回帰バグを防ぐ
+- **Minitest（request/integration主軸 + 重要導線のみsystem test）**
+    - 基本は request/integration test で回帰を検知し、速度と保守性を優先する
+    - ただし、壊れると影響が大きい導線（例：ログイン、投稿、チャット）は system test を最小本数で追加し、UI挙動も回帰検知する
+    - 詳細な運用方針は `docs/03_engineering/testing/2026-02-08-01-testing-policy-minitest.md` と `docs/03_engineering/testing/2026-02-23-01-system-test-foundation-runbook.md` を参照
 
 ---
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  allow_unauthenticated_access only: %i[ new create ]
+  unauthenticated_access_only only: %i[new create]
   rate_limit to: 10, within: 3.minutes, only: :create,
              with: -> { handle_create_rate_limit }
 

--- a/docs/03_engineering/testing/2026-02-08-01-testing-policy-minitest.md
+++ b/docs/03_engineering/testing/2026-02-08-01-testing-policy-minitest.md
@@ -6,7 +6,7 @@
 ## 結論
 - 現在は **Minitest** を採用する。
 - テストは **request/integration test を主軸** にし、重要導線のみ system test を追加する。
-- CI は既存の `bin/rails db:test:prepare test test:system` を継続する。
+- CI は `bin/rails test` を基本に運用し、system test は実行基盤整備後に段階的に組み込む。
 
 ## Minitestを採用する理由
 - Railsデフォルトであること。既存構成（Gem/CI/生成物）が Minitest 前提で、追加導入コストが最小。

--- a/docs/03_engineering/testing/2026-02-23-01-system-test-foundation-runbook.md
+++ b/docs/03_engineering/testing/2026-02-23-01-system-test-foundation-runbook.md
@@ -1,0 +1,131 @@
+# Issue #153 実行ランブック: Systemテスト基盤整備と最小E2E追加
+
+## 目的
+- `bin/rails test:system` をローカル/CIで安定実行できる状態を作る。
+- 重要導線（認証/投稿/チャット）に最小限のsystemテストを追加し、UI挙動を回帰検知できるようにする。
+- request/integration中心の既存方針を維持しつつ、systemテストの担当範囲を明文化する。
+
+## 結論
+- このIssueでは「環境整備 -> 最小3導線のsystemテスト追加 -> docs更新」の順で進める。
+- systemテストは増やしすぎず、壊れたときの影響が大きい導線に限定する。
+- CI runnerは `ubuntu-latest` のままでも、テスト実行は `Dockerfile.dev` + `docker-compose.test.yml` に統一して再現性を担保する。
+
+## ローカル一次情報（このリポジトリの事実）
+- `Gemfile.lock`
+  - `rails (8.1.2)`
+  - `capybara (3.40.0)`
+  - `selenium-webdriver (4.41.0)`
+- `test/application_system_test_case.rb`
+  - `driven_by :selenium, using: :headless_chrome`
+- `Makefile`
+  - `make test` は `bin/rails test` と `bin/rails test:system` を連続実行する。
+- `.github/workflows/ci.yml`
+  - 現状は `bin/rails test --exclude '/RackAttackThrottleTest/'` までで、`test:system` は未実行。
+
+## 一次ソース（公式）
+- Rails Guides: Testing Rails Applications（System Testing）
+  - https://guides.rubyonrails.org/testing.html#system-testing
+- Selenium公式: Selenium Manager
+  - https://www.selenium.dev/documentation/selenium_manager/
+- Selenium公式: Chrome WebDriver
+  - https://www.selenium.dev/documentation/webdriver/browsers/chrome/
+- GitHub公式: actions/runner-images（`ubuntu-latest` の扱い）
+  - https://github.com/actions/runner-images
+
+## 実装方針
+### 1. systemテスト実行環境の整備
+- Docker（test実行コンテナ）に、Chrome/ChromeDriver実行に必要なブラウザ実行環境を追加する。
+- 依存追加時は「aptでブラウザ/driverを導入し、足りない共有ライブラリを `ldd` で特定して補完する」手順を使う。
+- コンテナ内で次を通す。
+  - `bin/rails test:system`
+
+### 2. CIにsystemテストを組み込む
+- `ci.yml` の test jobを `make test` 実行に寄せ、`Dockerfile.dev` ベースで `bin/rails test:system` まで実行する。
+- `tmp/screenshots` をartifact保存し、失敗時の調査可能性を確保する。
+- artifact保持期間は `retention-days: 1` とし、長期保管を避ける。
+
+### 3. 最小3導線のsystemテストを追加
+- 認証導線: ログイン成功/失敗（主要1導線）
+- 投稿導線: 投稿作成（主要1導線）
+- チャット導線: チャット表示・送信（主要1導線）
+- 既存request/integrationテストと責務を重複させず、UI操作と遷移確認に絞る。
+
+## 実装済みsystemテスト（Issue #153）
+### 認証
+- `test/system/authentication_system_test.rb`
+  - 未ログインで `timeline` / `similar_timeline` へ直アクセスした場合にログイン画面へ遷移
+  - ログイン失敗 -> 再入力 -> ログイン成功
+  - ログイン済みで `new_session_path` / `new_sign_up_path` へアクセスした場合にタイムラインへリダイレクト
+- `test/integration/authentication_flow_test.rb`
+  - ログイン済みで `POST /session` を実行した場合に拒否され、未認証専用導線へ進めないことを確認
+
+### 投稿
+- `test/system/post_creation_system_test.rb`
+  - タイムライン投稿フォームから投稿作成し、受付確認カードを表示
+  - 141文字入力時に送信ボタンが無効化される（`post_body_length`）
+  - 140文字ちょうどは送信できる（境界値）
+- `test/integration/posts_flow_test.rb`
+  - 未ログインで `POST /posts` を直叩きした場合に投稿作成されず、ログイン画面へリダイレクトされることを確認
+
+### チャット
+- `test/system/chat_message_system_test.rb`
+  - チャット詳細で送信できる
+  - 連投不可時に送信UIが無効化される
+  - 141文字入力時に送信ボタンが無効化される（`post_body_length`）
+  - 140文字ちょうどは送信できる（境界値）
+  - 一覧バッジ（新着/返信待ち）の遷移
+  - 詳細表示時の既読自動送信（`chat-read`）
+  - 詳細表示時の最下部スクロール（`chat-scroll`）
+  - 非参加ユーザーの直アクセス拒否（認可）
+  - 未ログインユーザーの直アクセス拒否（認証）
+
+### サインアップ/ポリシーUI
+- `test/system/sign_up_frontend_system_test.rb`
+  - 規約未同意で submit disabled、条件達成で enabled（`sign-up-submit` / `password-rules`）
+  - パスワード条件未達成で submit が有効化されないこと
+- `test/system/policy_modal_system_test.rb`
+  - 利用規約リンク押下でモーダル表示、閉じるで非表示（`policy-modal`）
+
+### 4. docs更新
+- 本ドキュメントに、運用ルールと追加時の基準を維持管理する。
+- `docs/03_engineering/testing/2026-02-08-01-testing-policy-minitest.md` と README のテスト説明を整合させる。
+
+## 実作業チェックリスト
+1. `Dockerfile.dev` にsystemテスト用ブラウザ実行環境を追加する。
+2. `make dev-build` で再ビルドし、`make test` が通ることを確認する。
+3. `test/system/` を作成し、認証/投稿/チャットの3本を追加する。
+4. `.github/workflows/ci.yml` で `test:system` を実行し、失敗時artifactを保存する。
+5. ローカルとCIで `make test` 相当が安定して通ることを確認する。
+6. docs更新（README、testing policy、本ランブック）を完了する。
+
+## 受け入れ条件との対応
+- `make test`（`bin/rails test` + `bin/rails test:system`）がローカルで安定実行できる。
+- CIでもsystemテストが定常実行され、失敗時に調査情報を取得できる。
+- 追加したsystemテストが、認証/投稿/チャットの主要導線の回帰検知に使える。
+- 「integrationとの棲み分け」と「systemテスト追加基準」がdocsに明記されている。
+
+## 既知リスクと回避策
+- `ubuntu-latest` 変動の影響を受けるリスク
+  - 回避策: test jobの実行環境を `Dockerfile.dev` に寄せ、依存をDocker側で固定する。
+- systemテスト増加によるCI時間悪化
+  - 回避策: 最小3導線から開始し、追加時は「ユーザー価値に直結する導線」に限定する。
+- headless環境の不安定化（表示タイミング/スクリーンショット不足）
+  - 回避策: 失敗時artifact保存、待機条件の明示、1テスト1責務で切り分けやすく保つ。
+- スクリーンショットartifactの情報露出リスク
+  - 回避策: テストデータは原則ダミーのみを使う。`security-privacy-check` と GitGuardian を継続運用し、漏えい兆候を監視する。
+
+## ローカル確認コマンド
+```bash
+# 全体
+make test
+
+# systemのみ
+docker compose --env-file .env.test -f docker-compose.dev.yml -f docker-compose.test.yml \
+  run --rm --workdir /app -e HOME=/tmp --user "$(id -u):$(id -g)" -e RAILS_ENV=test \
+  web bash -lc 'bin/rails db:test:prepare && bin/rails test:system'
+```
+
+## 関連ドキュメント
+- `docs/03_engineering/testing/2026-02-08-01-testing-policy-minitest.md`
+- `docs/03_engineering/ci/2026-02-08-01-github-actions-rubocop-brakeman-min-tests.md`
+- `README.md`

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,13 @@
 require "test_helper"
+require_relative "test_helpers/system_auth_test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+  include SystemAuthTestHelper
+
+  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ] do |options|
+    options.binary = "/usr/bin/chromium"
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--window-size=1400,1400")
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -14,7 +14,7 @@ class SessionsControllerTest < ActionController::TestCase
   test "return_to_after_authenticating(ログイン後のリダイレクト先）に外部URLが注入されたら全体TLにフォールバックする" do
     session[:return_to_after_authenticating] = "https://evil.example/phishing"
 
-    post :create, params: { email_address: @user.email_address, password: "password" }
+    post :create, params: { email_address: @user.email_address, password: "password12345" }
 
     assert_redirected_to timeline_url
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,4 +1,4 @@
-<% password_digest = BCrypt::Password.create("password") %>
+<% password_digest = BCrypt::Password.create("password12345") %>
 
 one:
   email_address: one@example.com

--- a/test/integration/authentication_flow_test.rb
+++ b/test/integration/authentication_flow_test.rb
@@ -13,7 +13,7 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
 
   test "ログイン成功" do
     assert_difference("Session.count", 1) do
-      post session_path, params: { email_address: @user.email_address, password: "password" }
+      post session_path, params: { email_address: @user.email_address, password: "password12345" }
     end
 
     assert_response :redirect
@@ -60,6 +60,18 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
 
     get root_path
 
+    assert_redirected_to timeline_path
+  end
+
+  test "ログイン済みでログイン処理を実行するとルートへリダイレクトされる" do
+    sign_in_as(@user)
+
+    assert_no_difference("Session.count") do
+      post session_path, params: { email_address: @user.email_address, password: "password12345" }
+    end
+
+    assert_redirected_to root_path
+    follow_redirect!
     assert_redirected_to timeline_path
   end
 
@@ -110,7 +122,7 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
     get protected_page_path
     assert_redirected_to new_session_path
 
-    post session_path, params: { email_address: @user.email_address, password: "password" }
+    post session_path, params: { email_address: @user.email_address, password: "password12345" }
 
     assert_redirected_to protected_page_path
     assert cookies[:session_id].present?
@@ -120,13 +132,13 @@ class AuthenticationFlowTest < ActionDispatch::IntegrationTest
     get protected_page_path
     assert_redirected_to new_session_path
 
-    post session_path, params: { email_address: @user.email_address, password: "password" }
+    post session_path, params: { email_address: @user.email_address, password: "password12345" }
     assert_redirected_to protected_page_path
 
     delete session_path
     assert_redirected_to new_session_path
 
-    post session_path, params: { email_address: @user.email_address, password: "password" }
+    post session_path, params: { email_address: @user.email_address, password: "password12345" }
     assert_redirected_to timeline_url
   end
 

--- a/test/integration/posts_flow_test.rb
+++ b/test/integration/posts_flow_test.rb
@@ -8,6 +8,14 @@ class PostsFlowTest < ActionDispatch::IntegrationTest
     FilterTerm.delete_all
   end
 
+  test "未ログインユーザーは投稿作成できない" do
+    assert_no_difference("Post.count") do
+      post posts_path, params: { post: { body: "unauthorized post" } }
+    end
+
+    assert_redirected_to new_session_path
+  end
+
   test "ログイン済みユーザーはタイムラインで投稿フォームを表示できる" do
     sign_in_as(users(:one))
 

--- a/test/system/authentication_system_test.rb
+++ b/test/system/authentication_system_test.rb
@@ -1,0 +1,53 @@
+require "application_system_test_case"
+
+class AuthenticationSystemTest < ApplicationSystemTestCase
+  test "未ログインでタイムラインへアクセスするとログイン画面へ遷移する" do
+    visit timeline_path
+
+    assert_current_path new_session_path
+  end
+
+  test "未ログインでおすすめタイムラインへアクセスするとログイン画面へ遷移する" do
+    visit similar_timeline_path
+
+    assert_current_path new_session_path
+  end
+
+  test "ログイン失敗後に再入力してログイン成功できる" do
+    visit new_session_path
+
+    within all("form[action='#{session_path}']").first do
+      fill_in "email_address", with: users(:one).email_address
+      fill_in "password", with: "wrong-password"
+      click_button "ログイン"
+    end
+
+    assert_current_path new_session_path
+    assert_text "メールアドレスまたはパスワードが異なります。"
+
+    within all("form[action='#{session_path}']").first do
+      fill_in "email_address", with: users(:one).email_address
+      fill_in "password", with: "password12345"
+      click_button "ログイン"
+    end
+
+    assert_current_path timeline_path
+    assert_selector "h1", text: "全体タイムライン"
+  end
+
+  test "ログイン済みでログイン画面へアクセスするとタイムラインへ戻る" do
+    login_as(users(:one))
+
+    visit new_session_path
+
+    assert_current_path timeline_path
+  end
+
+  test "ログイン済みでユーザー登録画面へアクセスするとタイムラインへ戻る" do
+    login_as(users(:one))
+
+    visit new_sign_up_path
+
+    assert_current_path timeline_path
+  end
+end

--- a/test/system/chat_message_system_test.rb
+++ b/test/system/chat_message_system_test.rb
@@ -1,0 +1,175 @@
+require "application_system_test_case"
+
+class ChatMessageSystemTest < ApplicationSystemTestCase
+  setup do
+    @owner = users(:one)
+    @replier = users(:two)
+    @post = @owner.posts.create!(body: "system chat target")
+    @chatroom, = Chatroom.start_with_message!(post: @post, reply_user: @replier, body: "先行メッセージ")
+  end
+
+  test "チャット詳細でメッセージを送信できる" do
+    login_as(@owner)
+
+    visit chat_path(@chatroom)
+
+    assert_selector "h1", text: "チャット"
+    find("form[action='#{chat_messages_path(@chatroom)}'] textarea[name='chat_message[body]']").set("system返信")
+    find("form[action='#{chat_messages_path(@chatroom)}'] button[type='submit']").click
+
+    assert_current_path chat_path(@chatroom)
+    assert_text "system返信"
+  end
+
+  test "連続送信不可のときは送信ボタンが無効化される" do
+    login_as(@replier)
+
+    visit chat_path(@chatroom)
+
+    assert_text ChatMessage::CONSECUTIVE_SEND_MESSAGE
+    assert_selector "form[action='#{chat_messages_path(@chatroom)}'] textarea[name='chat_message[body]'][disabled]"
+    assert_selector "form[action='#{chat_messages_path(@chatroom)}'] button.btn-disabled"
+  end
+
+  test "チャットフォームで140字超過時は送信が無効化される" do
+    login_as(@owner)
+
+    visit chat_path(@chatroom)
+
+    form_selector = "form[action='#{chat_messages_path(@chatroom)}']"
+    textarea = find("#{form_selector} textarea[name='chat_message[body]']")
+    textarea.set("c" * 141)
+    page.execute_script("arguments[0].dispatchEvent(new Event('input', { bubbles: true }))", textarea)
+
+    assert_text "140字を超えているため送信できません。"
+    assert page.evaluate_script("arguments[0].disabled", find("#{form_selector} button[type='submit']"))
+  end
+
+  test "チャットフォームで140字ちょうどは送信できる" do
+    login_as(@owner)
+
+    visit chat_path(@chatroom)
+
+    body = "d" * 140
+    form_selector = "form[action='#{chat_messages_path(@chatroom)}']"
+    textarea = find("#{form_selector} textarea[name='chat_message[body]']")
+    textarea.set(body)
+    page.execute_script("arguments[0].dispatchEvent(new Event('input', { bubbles: true }))", textarea)
+    assert_equal false, page.evaluate_script("arguments[0].disabled", find("#{form_selector} button[type='submit']"))
+
+    find("#{form_selector} button[type='submit']").click
+    assert_current_path chat_path(@chatroom)
+    assert_text body
+  end
+
+  test "チャット一覧の新着/返信待ちバッジが送信で遷移する" do
+    login_as(@owner)
+
+    visit chats_path
+    within("a[href='#{chat_path(@chatroom)}']") do
+      assert_text "新着"
+    end
+
+    visit chat_path(@chatroom)
+    find("form[action='#{chat_messages_path(@chatroom)}'] textarea[name='chat_message[body]']").set("バッジ遷移確認")
+    find("form[action='#{chat_messages_path(@chatroom)}'] button[type='submit']").click
+    assert_current_path chat_path(@chatroom)
+    assert_text "バッジ遷移確認"
+
+    visit chats_path
+    within("a[href='#{chat_path(@chatroom)}']") do
+      assert_text "返信待ち"
+      assert_no_text "新着"
+    end
+
+    Capybara.reset_sessions!
+    login_as(@replier)
+    visit chats_path
+    within("a[href='#{chat_path(@chatroom)}']") do
+      assert_text "新着"
+      assert_no_text "返信待ち"
+    end
+  end
+
+  test "チャット詳細表示時に既読送信され新着バッジが消える" do
+    login_as(@owner)
+
+    visit chats_path
+    within("a[href='#{chat_path(@chatroom)}']") do
+      assert_text "新着"
+    end
+
+    visit chat_path(@chatroom)
+    wait_for { @chatroom.reload.has_unread == false }
+
+    visit chats_path
+    within("a[href='#{chat_path(@chatroom)}']") do
+      assert_no_text "新着"
+    end
+  end
+
+  test "チャット詳細表示時にメッセージ一覧が最下部へスクロールされる" do
+    append_messages_for_scroll_test!
+    login_as(@owner)
+
+    visit chat_path(@chatroom)
+    assert_selector "[data-chat-scroll-target='messages']"
+
+    scroll_gap = page.evaluate_script(<<~JS)
+      (() => {
+        const el = document.querySelector("[data-chat-scroll-target='messages']")
+        return el.scrollHeight - el.scrollTop - el.clientHeight
+      })()
+    JS
+
+    assert_operator scroll_gap, :<=, 2
+  end
+
+  test "非参加ユーザーでチャット詳細へ直アクセスすると拒否される" do
+    outsider = User.create!(
+      email_address: "outsider-system@example.com",
+      password: "password12345",
+      password_confirmation: "password12345",
+      terms_agreed: "1"
+    )
+    login_as(outsider)
+
+    visit chat_path(@chatroom)
+
+    assert_current_path timeline_path
+    assert_text "このチャットにはアクセスできません。"
+  end
+
+  test "未ログインでチャット詳細へ直アクセスするとログイン画面へ遷移する" do
+    visit chat_path(@chatroom)
+
+    assert_current_path new_session_path
+  end
+
+  private
+
+  def append_messages_for_scroll_test!
+    room_id = @chatroom.id
+    sender = @owner
+
+    24.times do |i|
+      room = Chatroom.find(room_id)
+      ChatMessage.create_in_room!(chatroom: room, user: sender, body: "scroll-message-#{i}")
+      sender = (sender == @owner ? @replier : @owner)
+    end
+
+    @chatroom.reload
+  end
+
+  def wait_for(timeout: Capybara.default_max_wait_time)
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    loop do
+      return if yield
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+      raise "wait_for timeout" if elapsed > timeout
+
+      sleep 0.05
+    end
+  end
+end

--- a/test/system/policy_modal_system_test.rb
+++ b/test/system/policy_modal_system_test.rb
@@ -1,0 +1,14 @@
+require "application_system_test_case"
+
+class PolicyModalSystemTest < ApplicationSystemTestCase
+  test "利用規約リンクでモーダル表示し閉じるで非表示になる" do
+    visit new_sign_up_path
+
+    click_link "利用規約"
+    assert_selector "#policy_modal_overlay"
+    assert_selector "#policy_modal .tt-policy-title", text: "利用規約"
+
+    find("#policy_modal button[aria-label='閉じる']").click
+    assert_no_selector "#policy_modal_overlay"
+  end
+end

--- a/test/system/post_creation_system_test.rb
+++ b/test/system/post_creation_system_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class PostCreationSystemTest < ApplicationSystemTestCase
+  test "タイムラインから投稿作成して受付確認カードを表示する" do
+    login_as(users(:one))
+
+    within all("form.tt-compose-form").first do
+      find("textarea[name='post[body]']").set("system投稿テスト")
+      click_on "投稿"
+    end
+
+    assert_current_path similar_timeline_path
+    assert_selector ".tt-post-confirm-card"
+    assert_selector ".tt-post-confirm-title", text: "あなたの投稿を受付けました"
+    assert_selector ".tt-post-confirm-body", text: "system投稿テスト"
+  end
+
+  test "投稿フォームで140字超過時は送信が無効化される" do
+    login_as(users(:one))
+
+    within all("form.tt-compose-form").first do
+      textarea = find("textarea[name='post[body]']")
+      textarea.set("a" * 141)
+      page.execute_script("arguments[0].dispatchEvent(new Event('input', { bubbles: true }))", textarea)
+      assert page.evaluate_script("arguments[0].disabled", find("input[type='submit']"))
+      assert_text "140字を超えているため投稿できません。"
+    end
+
+    assert_current_path timeline_path
+  end
+
+  test "投稿フォームで140字ちょうどは送信できる" do
+    login_as(users(:one))
+
+    body = "b" * 140
+    within all("form.tt-compose-form").first do
+      textarea = find("textarea[name='post[body]']")
+      textarea.set(body)
+      page.execute_script("arguments[0].dispatchEvent(new Event('input', { bubbles: true }))", textarea)
+      assert_equal false, page.evaluate_script("arguments[0].disabled", find("input[type='submit']"))
+      click_on "投稿"
+    end
+
+    assert_current_path similar_timeline_path
+    assert_selector ".tt-post-confirm-body", text: body
+  end
+end

--- a/test/system/sign_up_frontend_system_test.rb
+++ b/test/system/sign_up_frontend_system_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+class SignUpFrontendSystemTest < ApplicationSystemTestCase
+  test "利用規約未同意ではsubmit無効、条件達成で有効になる" do
+    visit new_sign_up_path
+
+    fill_in "user_email_address", with: "new_frontend_user@example.com"
+    fill_in "user_password", with: "abc123def456"
+    fill_in "user_password_confirmation", with: "abc123def456"
+
+    submit = find("input[type='submit'][value='登録する']")
+    assert page.evaluate_script("arguments[0].disabled", submit)
+
+    check "user_terms_agreed"
+    assert_equal false, page.evaluate_script("arguments[0].disabled", submit)
+    assert_text "英字と数字を含む - OK"
+    assert_text "12文字以上 - OK"
+  end
+
+  test "パスワード条件未達成のときsubmitは有効化されない" do
+    visit new_sign_up_path
+
+    fill_in "user_email_address", with: "invalid_frontend_user@example.com"
+    fill_in "user_password", with: "abcdefghijkl"
+    fill_in "user_password_confirmation", with: "abcdefghijkl"
+    check "user_terms_agreed"
+
+    submit = find("input[type='submit'][value='登録する']")
+    assert page.evaluate_script("arguments[0].disabled", submit)
+    assert_text "英字と数字を含む - 未達成"
+    assert_text "12文字以上 - OK"
+  end
+end

--- a/test/test_helpers/system_auth_test_helper.rb
+++ b/test/test_helpers/system_auth_test_helper.rb
@@ -1,0 +1,13 @@
+module SystemAuthTestHelper
+  def login_as(user, password: "password12345")
+    visit new_session_path
+
+    within all("form[action='#{session_path}']").first do
+      fill_in "email_address", with: user.email_address
+      fill_in "password", with: password
+      click_button "ログイン"
+    end
+
+    assert_current_path timeline_path
+  end
+end


### PR DESCRIPTION
## 目的
- systemテストをローカル/CIで安定実行できる基盤を整備する
- 認証/投稿/チャット/サインアップUIの主要導線をsystemテストで回帰検知できるようにする
- ログイン済みユーザーの未認証専用導線アクセスをサーバ側でも防ぐ

## 結論
- CIのテスト実行を `make test` に統一し、`Dockerfile.dev` + compose経路で `test:system` まで実行する構成に変更
- systemテストを新規追加し、主要UI挙動と認証/認可導線の最低限カバレッジを実装
- `SessionsController` を `unauthenticated_access_only only: %i[new create]` に変更し、ログイン済み `POST /session` を拒否する回帰テストを追加

## 変更点
- CI
  - `.github/workflows/ci.yml` を更新し `make test` 実行へ移行
  - 失敗時のみ `tmp/screenshots/failures_*.png` を artifact 保存
  - `retention-days: 1` を設定
- 実行環境
  - `Dockerfile.dev` に `chromium` `chromium-driver` `fonts-noto-cjk` を追加
  - ビルド時に `chromium --version` `chromedriver --version` を確認
- テスト基盤
  - `test/application_system_test_case.rb` で headless Chromium設定を明示
  - `test/test_helpers/system_auth_test_helper.rb` を追加して `login_as` を共通化
- systemテスト追加
  - `test/system/authentication_system_test.rb`
  - `test/system/post_creation_system_test.rb`
  - `test/system/chat_message_system_test.rb`
  - `test/system/policy_modal_system_test.rb`
  - `test/system/sign_up_frontend_system_test.rb`
- integrationテスト追加/更新
  - `test/integration/posts_flow_test.rb` に未ログイン投稿拒否を追加
  - `test/integration/authentication_flow_test.rb` にログイン済み `POST /session` 拒否を追加
  - `follow_redirect!` で最終到達 `timeline_path` まで検証
- 認証制御
  - `app/controllers/sessions_controller.rb` を更新
- フィクスチャ/既存テスト追随
  - `test/fixtures/users.yml` のパスワードを `password12345` に変更し関連テストを更新
- ドキュメント
  - `docs/03_engineering/testing/2026-02-23-01-system-test-foundation-runbook.md` を新規追加
  - README と testing policy を現行方針に合わせて更新

## 動作確認
- テスト完走

## 参考資料（1次ソース）
- Rails Guides: Testing Rails Applications（System Testing）
- Selenium公式ドキュメント（Selenium Manager / Chrome WebDriver）
- GitHub Actions runner-images 公式リポジトリ

## 関連Issue
Closes #153
