### PR TITLE
WIP: WIP: 本番DB投入作業中に発生したvariant依存エラー回避のためproduction設定を調整

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,8 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  # MVPでは画像変換機能を使わないため、variant処理を無効化して依存gemを不要にする。
+  config.active_storage.variant_processor = :disabled
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true


### PR DESCRIPTION
## 目的
- 本番DB投入作業中に発生した Active Storage のvariant依存エラーを回避し、投入作業を継続可能にする

## 結論
- 本番環境で Active Storage のvariant処理を無効化した
- `image_processing` 未導入でも起動時エラーを避けられる状態にした

## 変更点
- `config/environments/production.rb`
- `config.active_storage.variant_processor = :disabled` を追加
- DB投入作業中の障害回避であることを意図コメントに反映

## 動作確認
- 本番デプロイ後に `tonetwo` の Logs で `image_processing` 関連エラーが消えていることを確認予定

## 参考資料（1次ソース）
- https://guides.rubyonrails.org/configuring.html#config-active-storage-variant-processor
