### PR TITLE
fix: Rack::Attackの切り分け用に閾値調整と429ログ即時出力を追加

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -11,7 +11,7 @@ class Rack::Attack
 
   # 未ログイン時の全体アクセスだけを粗く抑止する。
   # ログイン後の通常閲覧は、個別エンドポイントの制限に任せる。
-  throttle("req/ip", limit: 240, period: 1.minute) do |req|
+  throttle("req/ip", limit: 480, period: 1.minute) do |req|
     next if req.path == "/up"
     next if req.path.start_with?("/assets")
     next if req.path == "/favicon.ico"
@@ -52,7 +52,7 @@ class Rack::Attack
   # Rack::Attackで弾いたときに、監視イベントを記録して429を返す処理
   def self.throttled_response(request)
     ActiveSupport::Notifications.instrument("security.throttle", throttled_payload(request))
-    [ 429, { "Content-Type" => "text/plain" }, [ "Too Many Requests" ] ]
+    [ 429, { "Content-Type" => "text/plain" }, [ "429 Too Many Requests" ] ]
   end
 
   def self.throttled_payload(request)

--- a/config/initializers/security_throttle_observability.rb
+++ b/config/initializers/security_throttle_observability.rb
@@ -30,11 +30,19 @@ unless Rails.configuration.x.security_throttle_subscriber_registered
   end
 
   def should_emit_throttle_log?(count)
-    count == WARN_THRESHOLD || count == ERROR_THRESHOLD || (count > ERROR_THRESHOLD && (count % ERROR_THRESHOLD).zero?)
+    # 元の運用ロジック（切り戻し用）
+    # count == WARN_THRESHOLD || count == ERROR_THRESHOLD || (count > ERROR_THRESHOLD && (count % ERROR_THRESHOLD).zero?)
+
+    # 切り分け期間中は 429 を毎回記録する
+    true
   end
 
   def throttle_log_level(count)
-    count >= ERROR_THRESHOLD ? :error : :warn
+    # 元の運用ロジック（切り戻し用）
+    # count >= ERROR_THRESHOLD ? :error : :warn
+
+    # 切り分け期間中は通知漏れ防止のため常に error
+    :error
   end
 
   # layer を必須キーにして、middleware/controller の抑止シグナルを同一イベントで集計する


### PR DESCRIPTION
## 目的
- 本番で発生している 429 の切り分けをしやすくする

## 結論
- Rack::Attack の未ログイン全体スロットルを緩和し、429発生時の観測ログを即時出力に変更した

## 変更点
- `config/initializers/rack_attack.rb`
- `req/ip` の制限値を `240 -> 480` に変更
- 429レスポンス文言を `429 Too Many Requests` に変更し、もしもまたログ出力がなかった場合にRackAttack系のエラーであることを切り分けの手掛かりにする

- `config/initializers/security_throttle_observability.rb`
- 既存の閾値ベース集計ロジックはコメントで保持
- 切り分け期間中として、`security.throttle` を毎回出力する設定に変更
- ログレベルを常に `error` に変更



