### PR TITLE
fix: req/ipスロットルを240/minに戻して429再現確認を行う

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -11,7 +11,7 @@ class Rack::Attack
 
   # 未ログイン時の全体アクセスだけを粗く抑止する。
   # ログイン後の通常閲覧は、個別エンドポイントの制限に任せる。
-  throttle("req/ip", limit: 480, period: 1.minute) do |req|
+  throttle("req/ip", limit: 240, period: 1.minute) do |req|
     next if req.path == "/up"
     next if req.path.start_with?("/assets")
     next if req.path == "/favicon.ico"


### PR DESCRIPTION
## 目的
- 429の発生条件を切り分けるため、未ログイン全体スロットルの閾値を再調整する

## 結論
- `req/ip` の閾値を `480` から `240` に戻した

## 変更点
- `config/initializers/rack_attack.rb`
- `throttle("req/ip")` の `limit` を `240` に変更

## 動作確認
- 429再現確認をこれから実施
