### PR TITLE
fix: モバイル本文の可読性とナビアクティブ表示を調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -856,8 +856,8 @@
   }
 
   .tt-mobile-footer-nav-link .tt-header-icon {
-    width: 1.2rem;
-    height: 1.2rem;
+    width: 1.7rem;
+    height: 1.7rem;
   }
 
   .tt-mobile-footer-nav-label {
@@ -1012,6 +1012,13 @@
   }
 
   @media (max-width: 767px) {
+    /* 本文可読性向上のため、モバイル時のみ本文テキストを一段階拡大 */
+    .tt-post-body,
+    .tt-chat-bubble-body {
+      font-size: 1.0625rem;
+      line-height: 1.75;
+    }
+
     /* チャット見出しは左端寄りのため、モバイルではポップオーバーを左基準にして見切れを防ぐ */
     .tt-help-popover-chat {
       left: 0;

--- a/app/views/chats/_message_bubble.html.erb
+++ b/app/views/chats/_message_bubble.html.erb
@@ -2,7 +2,7 @@
 <% own_message = message.user_id == current_user.id %>
 <div class="space-y-1 px-4">
   <div class="flex <%= own_message ? "justify-end" : "justify-start" %>">
-    <div class="<%= own_message ? "bg-neutral text-neutral-content" : "bg-base-100 text-base-content" %> inline-block max-w-[85%] rounded-[1.35rem] px-5 py-3 text-left whitespace-pre-wrap break-words"><%= message.body.to_s.strip %></div>
+    <div class="<%= own_message ? "bg-neutral text-neutral-content" : "bg-base-100 text-base-content" %> tt-chat-bubble-body inline-block max-w-[85%] rounded-[1.35rem] px-5 py-3 text-left whitespace-pre-wrap break-words"><%= message.body.to_s.strip %></div>
   </div>
   <p class="px-1 text-[11px] text-base-content/50 <%= own_message ? "text-right" : "text-left" %>"><%= tt_datetime_label(posted_at) %></p>
 </div>

--- a/app/views/chats/_seed_post_bubble.html.erb
+++ b/app/views/chats/_seed_post_bubble.html.erb
@@ -2,7 +2,7 @@
 <% own_post = post.user_id == current_user.id %>
 <div class="space-y-2 px-4">
   <div class="flex <%= own_post ? "justify-end" : "justify-start" %>">
-    <div class="<%= own_post ? "bg-neutral text-neutral-content" : "bg-base-100 text-base-content" %> inline-block max-w-[85%] rounded-[1.35rem] px-5 py-3 text-left whitespace-pre-wrap break-words"><%= post.body.to_s.strip %></div>
+    <div class="<%= own_post ? "bg-neutral text-neutral-content" : "bg-base-100 text-base-content" %> tt-chat-bubble-body inline-block max-w-[85%] rounded-[1.35rem] px-5 py-3 text-left whitespace-pre-wrap break-words"><%= post.body.to_s.strip %></div>
   </div>
   <p class="px-1 text-[11px] text-base-content/50 <%= own_post ? "text-right" : "text-left" %>"><%= tt_datetime_label(posted_at) %></p>
 </div>

--- a/app/views/shared/_site_header.html.erb
+++ b/app/views/shared/_site_header.html.erb
@@ -1,7 +1,7 @@
 <% if authenticated? %>
   <% timeline_active = current_page?(timeline_path) %>
   <% similar_active = current_page?(similar_timeline_path) %>
-  <% my_posts_active = current_page?(my_posts_path) %>
+  <% my_posts_active = current_page?(my_posts_path) || controller_path == "my/posts" %>
   <% chats_active = current_page?(chats_path) || controller_name == "chats" %>
   <% settings_active = current_page?(settings_path) %>
 


### PR DESCRIPTION
## 目的
- スマホ表示時の本文可読性とナビゲーションの視認性を改善する

## 結論
- モバイル時の本文文字サイズと下部ナビアイコンサイズを調整
- MY投稿詳細でもナビをアクティブ表示するようにした

## 変更点
- `app/assets/stylesheets/application.tailwind.css`
- モバイル下部ナビのアイコンサイズを拡大
- モバイル時のみ `.tt-post-body` と `.tt-chat-bubble-body` のフォントサイズ・行間を拡大

- `app/views/chats/_message_bubble.html.erb`
- `app/views/chats/_seed_post_bubble.html.erb`
- チャット本文に `tt-chat-bubble-body` クラスを付与

- `app/views/shared/_site_header.html.erb`
- `my/posts#show` でも `MY投稿` がアクティブになるよう判定条件を追加
