### PR TITLE
chore(deps): solid_queueを1.3.2へ更新しライセンス文書と関連テストを同期

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,8 +125,9 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.2)
-    irb (1.16.0)
+    irb (1.17.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jbuilder (2.14.1)
@@ -245,7 +246,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
-    rdoc (7.1.0)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -299,7 +300,7 @@ GEM
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
-    solid_queue (1.3.1)
+    solid_queue (1.3.2)
       activejob (>= 7.1)
       activerecord (>= 7.1)
       concurrent-ruby (>= 1.3.1)
@@ -342,7 +343,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.4)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   x86_64-linux

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-02-23 04:27:49 +0900
+最終更新日時: 2026-02-23 23:07:09 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -42,7 +42,7 @@
 | i18n | 1.14.8 | MIT | https://github.com/ruby-i18n/i18n |
 | importmap-rails | 2.2.3 | MIT | https://github.com/rails/importmap-rails |
 | io-console | 0.8.2 | Ruby, BSD-2-Clause | https://github.com/ruby/io-console |
-| irb | 1.16.0 | Ruby, BSD-2-Clause | https://github.com/ruby/irb |
+| irb | 1.17.0 | Ruby, BSD-2-Clause | https://github.com/ruby/irb |
 | jbuilder | 2.14.1 | MIT | https://github.com/rails/jbuilder |
 | json | 2.18.1 | Ruby | https://github.com/ruby/json |
 | kamal | 2.10.1 | MIT | https://github.com/basecamp/kamal |
@@ -83,12 +83,12 @@
 | rails-html-sanitizer | 1.6.2 | MIT | https://github.com/rails/rails-html-sanitizer |
 | railties | 8.1.2 | MIT | https://rubyonrails.org |
 | rake | 13.3.1 | MIT | https://github.com/ruby/rake |
-| rdoc | 7.1.0 | Ruby | https://ruby.github.io/rdoc |
+| rdoc | 7.2.0 | Ruby | https://ruby.github.io/rdoc |
 | reline | 0.6.3 | Ruby | https://github.com/ruby/reline |
 | securerandom | 0.4.1 | Ruby, BSD-2-Clause | https://github.com/ruby/securerandom |
 | solid_cable | 3.0.12 | MIT | https://github.com/rails/solid_cable |
 | solid_cache | 1.0.10 | MIT | http://github.com/rails/solid_cache |
-| solid_queue | 1.3.1 | MIT | https://github.com/rails/solid_queue |
+| solid_queue | 1.3.2 | MIT | https://github.com/rails/solid_queue |
 | sshkit | 1.25.0 | MIT | http://github.com/capistrano/sshkit |
 | stimulus-rails | 1.3.4 | MIT | https://stimulus.hotwired.dev |
 | stringio | 3.2.0 | Ruby, BSD-2-Clause | https://github.com/ruby/stringio |
@@ -102,4 +102,4 @@
 | useragent | 0.16.11 | MIT | https://github.com/gshutler/useragent |
 | websocket-driver | 0.8.0 | Apache-2.0 | https://github.com/faye/websocket-driver-ruby |
 | websocket-extensions | 0.1.5 | Apache-2.0 | https://github.com/faye/websocket-extensions-ruby |
-| zeitwerk | 2.7.4 | MIT | https://github.com/fxn/zeitwerk |
+| zeitwerk | 2.7.5 | MIT | https://github.com/fxn/zeitwerk |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-02-23 04:27:49 +0900
+最終更新日時: 2026-02-23 23:07:09 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -95,7 +95,7 @@
 | i18n | 1.14.8 | MIT | https://github.com/ruby-i18n/i18n |
 | importmap-rails | 2.2.3 | MIT | https://github.com/rails/importmap-rails |
 | io-console | 0.8.2 | Ruby, BSD-2-Clause | https://github.com/ruby/io-console |
-| irb | 1.16.0 | Ruby, BSD-2-Clause | https://github.com/ruby/irb |
+| irb | 1.17.0 | Ruby, BSD-2-Clause | https://github.com/ruby/irb |
 | jbuilder | 2.14.1 | MIT | https://github.com/rails/jbuilder |
 | json | 2.18.1 | Ruby | https://github.com/ruby/json |
 | kamal | 2.10.1 | MIT | https://github.com/basecamp/kamal |
@@ -136,12 +136,12 @@
 | rails-html-sanitizer | 1.6.2 | MIT | https://github.com/rails/rails-html-sanitizer |
 | railties | 8.1.2 | MIT | https://rubyonrails.org |
 | rake | 13.3.1 | MIT | https://github.com/ruby/rake |
-| rdoc | 7.1.0 | Ruby | https://ruby.github.io/rdoc |
+| rdoc | 7.2.0 | Ruby | https://ruby.github.io/rdoc |
 | reline | 0.6.3 | Ruby | https://github.com/ruby/reline |
 | securerandom | 0.4.1 | Ruby, BSD-2-Clause | https://github.com/ruby/securerandom |
 | solid_cable | 3.0.12 | MIT | https://github.com/rails/solid_cable |
 | solid_cache | 1.0.10 | MIT | http://github.com/rails/solid_cache |
-| solid_queue | 1.3.1 | MIT | https://github.com/rails/solid_queue |
+| solid_queue | 1.3.2 | MIT | https://github.com/rails/solid_queue |
 | sshkit | 1.25.0 | MIT | http://github.com/capistrano/sshkit |
 | stimulus-rails | 1.3.4 | MIT | https://stimulus.hotwired.dev |
 | stringio | 3.2.0 | Ruby, BSD-2-Clause | https://github.com/ruby/stringio |
@@ -155,7 +155,7 @@
 | useragent | 0.16.11 | MIT | https://github.com/gshutler/useragent |
 | websocket-driver | 0.8.0 | Apache-2.0 | https://github.com/faye/websocket-driver-ruby |
 | websocket-extensions | 0.1.5 | Apache-2.0 | https://github.com/faye/websocket-extensions-ruby |
-| zeitwerk | 2.7.4 | MIT | https://github.com/fxn/zeitwerk |
+| zeitwerk | 2.7.5 | MIT | https://github.com/fxn/zeitwerk |
 
 
 ---

--- a/test/integration/rack_attack_throttle_test.rb
+++ b/test/integration/rack_attack_throttle_test.rb
@@ -36,19 +36,6 @@ class RackAttackThrottleTest < ActionDispatch::IntegrationTest
     travel_back
   end
 
-  test "basic auth付きリクエストは上限超過で429を返す" do
-    headers = { "HTTP_AUTHORIZATION" => "Basic dGVzdDp0ZXN0" }
-
-    20.times do
-      get new_session_path, headers: headers, env: @request_env
-      assert_response :success
-    end
-
-    get new_session_path, headers: headers, env: @request_env
-    assert_response :too_many_requests
-    assert_equal "Too Many Requests", response.body
-  end
-
   test "通常リクエストは上限超過で429を返す" do
     240.times do
       get new_session_path, env: @request_env
@@ -57,7 +44,7 @@ class RackAttackThrottleTest < ActionDispatch::IntegrationTest
 
     get new_session_path, env: @request_env
     assert_response :too_many_requests
-    assert_equal "Too Many Requests", response.body
+    assert_equal "429 Too Many Requests", response.body
   end
 
   test "POST /session は上限超過で抑止される" do
@@ -69,7 +56,7 @@ class RackAttackThrottleTest < ActionDispatch::IntegrationTest
 
     post session_path, params: { email_address: "one@example.com", password: "wrong-password" }, env: @request_env
     assert_response :too_many_requests
-    assert_equal "Too Many Requests", response.body
+    assert_equal "429 Too Many Requests", response.body
   end
 
   test "POST /sign_up は上限超過で429を返す" do
@@ -92,7 +79,7 @@ class RackAttackThrottleTest < ActionDispatch::IntegrationTest
       }
     }, env: @request_env
     assert_response :too_many_requests
-    assert_equal "Too Many Requests", response.body
+    assert_equal "429 Too Many Requests", response.body
   end
 
   test "POST /posts は上限超過で429を返す" do
@@ -103,7 +90,7 @@ class RackAttackThrottleTest < ActionDispatch::IntegrationTest
 
     post posts_path, params: { post: { body: "rack attack test over limit" } }, env: @request_env
     assert_response :too_many_requests
-    assert_equal "Too Many Requests", response.body
+    assert_equal "429 Too Many Requests", response.body
   end
 
   test "POST /posts/:post_id/chat は上限超過で429を返す" do
@@ -114,7 +101,7 @@ class RackAttackThrottleTest < ActionDispatch::IntegrationTest
 
     post "/posts/1/chat", params: { chat_message: { body: "rack attack start chat test over limit" } }, env: @request_env
     assert_response :too_many_requests
-    assert_equal "Too Many Requests", response.body
+    assert_equal "429 Too Many Requests", response.body
   end
 
   test "POST /chats/:chat_id/messages は上限超過で429を返す" do
@@ -125,7 +112,7 @@ class RackAttackThrottleTest < ActionDispatch::IntegrationTest
 
     post "/chats/1/messages", params: { chat_message: { body: "rack attack chat test over limit" } }, env: @request_env
     assert_response :too_many_requests
-    assert_equal "Too Many Requests", response.body
+    assert_equal "429 Too Many Requests", response.body
   end
 
   private


### PR DESCRIPTION
## 目的
- Dependabot提案の `solid_queue` 更新を手動反映し、関連ドキュメントとテスト期待値を現行仕様に合わせる

## 結論
- `solid_queue` を `1.3.1 -> 1.3.2` に更新し、ライセンス生成物と RackAttack テストを整合させた

## 変更点
- `Gemfile.lock`
- `solid_queue 1.3.2` へ更新
- 依存解決に伴い `zeitwerk / irb / rdoc` も更新

- `docs/80_licenses/gems.md`
- `docs/80_licenses/licenses_full.md`
- `make license-report` 相当の更新を反映し、バージョン表記を最新化

- `test/integration/rack_attack_throttle_test.rb`
- 429本文期待値を現仕様 (`429 Too Many Requests`) に更新
- 廃止済み Basic認証スロットルに関するテストケースを削除

## 動作確認
- `make test-all` 実行
- 結果: pass（RuboCop / Brakeman / importmap audit / test / system test）

## 参考資料（1次ソース）
- Solid Queue Releases  
  https://github.com/rails/solid_queue/releases
- Solid Queue v1.3.2  
  https://github.com/rails/solid_queue/releases/tag/v1.3.2

## 関連Issue
Closes #160
