### PR TITLE
chore: CI workflow の既定権限を明示する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   # PRが作成/更新されたときに実行
   pull_request:
 
+permissions:
+  contents: read
+
 # 同じPRで新しい実行が始まったら古い実行をキャンセル
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## 目的
- GitHub Actions の CI workflow に既定権限を明示し、CodeQL の権限不足アラートを解消する

## 結論
- `.github/workflows/ci.yml` に workflow 全体の既定権限として `contents: read` を追加した

## 変更点
- `.github/workflows/ci.yml` に `permissions: contents: read` を追加
- `changes` job の `pull-requests: read` はそのまま残し、最小権限の方針を維持

## 動作確認
- これから走るCIで確認

## 参考資料（1次ソース）
- [Workflow syntax for GitHub Actions](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions)
