### PR TITLE
chore: CodeQL workflow に手動実行トリガーを追加

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,8 @@ name: CodeQL
 on:
   # 既存 CI と同様に、作成・更新されたすべての PR を解析する
   pull_request:
+  # 必要時に GitHub UI から main へ手動実行できるようにする
+  workflow_dispatch:
 
 permissions:
   actions: read


### PR DESCRIPTION
## 目的
- `main` に対して GitHub UI から CodeQL を手動実行できるようにする

## 結論
- `.github/workflows/codeql.yml` に `workflow_dispatch` を追加した

## 変更点
- `CodeQL` workflow の `on:` に `workflow_dispatch` を追加
- `pull_request` 実行はそのまま維持
- 必要時に `Actions` タブから `main` を選んで手動実行できるようにした

## 動作確認
- Github画面上で反映を確認予定

## 参考資料（1次ソース）
- [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
