### PR TITLE
chore: CodeQL を main マージ後にも実行する

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,10 @@ name: CodeQL
 on:
   # 既存 CI と同様に、作成・更新されたすべての PR を解析する
   pull_request:
+  # default branch の code scanning alert を更新する
+  push:
+    branches:
+      - main
   # 必要時に GitHub UI から main へ手動実行できるようにする
   workflow_dispatch:
 


### PR DESCRIPTION
## 目的
- `main` ブランチの Code scanning alert を更新し、Security タブの alert 状態を正しく反映させる

## 結論
- `.github/workflows/codeql.yml` に `push: branches: [main]` を追加した
- `pull_request` だけでは `main` の Security タブ側の alert が更新されず、open のまま残るため、`main` の再解析経路を追加した
- alert の close を確認できたら、`push: branches: [main]` は外して元の運用に戻す想定

## 変更点
- `CodeQL` workflow の `on:` に `push` を追加
- 対象ブランチを `main` に限定した
- 既存の `pull_request` と `workflow_dispatch` は維持した

## 動作確認
- このあとmainで回るか結果をGithub上で確認

## 参考資料（1次ソース）
- [Configuring advanced setup for code scanning](https://docs.github.com/en/code-security/how-tos/scan-code-for-vulnerabilities/configure-code-scanning/configuring-advanced-setup-for-code-scanning)
