### PR TITLE
chore: CodeQL の一時的な変更をもとに戻す

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,10 +4,6 @@ name: CodeQL
 on:
   # 既存 CI と同様に、作成・更新されたすべての PR を解析する
   pull_request:
-  # default branch の code scanning alert を更新する
-  push:
-    branches:
-      - main
   # 必要時に GitHub UI から main へ手動実行できるようにする
   workflow_dispatch:
 


### PR DESCRIPTION
## 目的
- 既存の Code scanning alert は手動 dismiss で運用し、CodeQL の一時的な `main` push 実行を元に戻す

## 結論
- `.github/workflows/codeql.yml` から `push: branches: [main]` を削除した
- CodeQL は `pull_request` と `workflow_dispatch` のみで実行する構成に戻した
- なお、既存の Code scanning alert はmainでの CI 成功後も自動では閉じなかったため、手動で dismiss した

## 変更点
- `CodeQL` workflow の `on:` から `push` を削除
- `pull_request` と `workflow_dispatch` は維持（ `workflow_dispatch`はあれば便利なので一応残しておく）
- 既存 alert の close は自動解消ではなく手動 dismiss で扱う前提に切り替えた

## 動作確認
- 既存の Code scanning alert は手動で dismiss 済み

## 参考資料（1次ソース）
- [Configuring advanced setup for code scanning](https://docs.github.com/en/code-security/how-tos/scan-code-for-vulnerabilities/configure-code-scanning/configuring-advanced-setup-for-code-scanning)
