### PR TITLE
chore: action_text-trixを2.1.17へ更新する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.16)
+    action_text-trix (2.1.17)
       railties
     actioncable (8.1.2)
       actionpack (= 8.1.2)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,11 +2,11 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-12 02:12:07 +0900
+最終更新日時: 2026-03-13 18:06:36 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
-| action_text-trix | 2.1.16 | MIT | https://github.com/basecamp/trix |
+| action_text-trix | 2.1.17 | MIT | https://github.com/basecamp/trix |
 | actioncable | 8.1.2 | MIT | https://rubyonrails.org |
 | actionmailbox | 8.1.2 | MIT | https://rubyonrails.org |
 | actionmailer | 8.1.2 | MIT | https://rubyonrails.org |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,11 +55,11 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-12 02:12:07 +0900
+最終更新日時: 2026-03-13 18:06:36 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
-| action_text-trix | 2.1.16 | MIT | https://github.com/basecamp/trix |
+| action_text-trix | 2.1.17 | MIT | https://github.com/basecamp/trix |
 | actioncable | 8.1.2 | MIT | https://rubyonrails.org |
 | actionmailbox | 8.1.2 | MIT | https://rubyonrails.org |
 | actionmailer | 8.1.2 | MIT | https://rubyonrails.org |


### PR DESCRIPTION
## 目的
- Dependabot alert で検出された `action_text-trix` の脆弱性に対応する

## 結論
- `action_text-trix` を `2.1.16` から `2.1.17` に更新した
- ライセンス一覧を更新後の依存内容に同期した

## 変更点
- `Gemfile.lock` の `action_text-trix` を `2.1.17` に更新
- `docs/80_licenses/gems.md` のバージョン表記と更新日時を更新
- `docs/80_licenses/licenses_full.md` のバージョン表記と更新日時を更新

## 動作確認
- `make test-all`完走

## 参考資料（1次ソース）
- https://github.com/basecamp/trix/security
- https://github.com/basecamp/trix

## 関連Issue
Closes #222
