### PR TITLE
chore: CIのpaths-filterをv4へ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             rails:


### PR DESCRIPTION
## 目的
- GitHub Actions の `dorny/paths-filter` を v3 から v4 へ更新する

## 変更点
- `.github/workflows/ci.yml` の `uses: dorny/paths-filter@v3` を `uses: dorny/paths-filter@v4` に変更

## 動作確認
- `make test-all`完走

## 参考資料（1次ソース）
- https://github.com/dorny/paths-filter/releases
- https://github.com/dorny/paths-filter/compare/v3.0.3...v4.0.0

## 関連Issue
Closes #223
