### PR TITLE
WIP: Administrate導入のGem追加と導入メモを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 ### Ruby / Rails
 - `Gemfile.lock` を確認する。
 - `Gemfile.lock` を直接編集しない。依存変更が必要な場合は、Bundler を通じて更新する。
+- 巻き戻しや差分調整のためであっても `Gemfile.lock` を手編集しない。必要なら `bundle install` / `bundle update` / `git diff` で差分を確認し、適切な手順で戻す。
 - 必要に応じて `bundle info <gem>` 等で実インストール版を確認する。
 - `Gemfile.lock` と矛盾する前提で実装しない。
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem "rack-attack", "~> 6.8"
 # CommonMark準拠でMarkdownをHTMLに変換するためのライブラリ
 gem "commonmarker"
 
+# 管理者用ダッシュボードを簡単に作成できるライブラリ
+gem "administrate"
+
 # ====================
 # 開発 + テスト
 # ====================

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,11 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    administrate (1.0.0)
+      actionpack (>= 6.0, < 9.0)
+      actionview (>= 6.0, < 9.0)
+      activerecord (>= 6.0, < 9.0)
+      kaminari (~> 1.2.2)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.21)
@@ -131,6 +136,18 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.18.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -321,6 +338,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  administrate
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman (~> 8.0.2)

--- a/docs/03_engineering/admin/2026-03-15-01-administrate-introduction-runbook.md
+++ b/docs/03_engineering/admin/2026-03-15-01-administrate-introduction-runbook.md
@@ -1,0 +1,70 @@
+# Administrate 導入メモ
+
+## 目的
+- Issue `#41` の着手前に、導入手順と実装論点を簡潔に整理する。
+
+## 前提
+- 技術スタックは [README.md](../../../README.md) を参照。
+- 採用判断は [2026-03-13-01-admin-gem-comparison.md](./2026-03-13-01-admin-gem-comparison.md) を参照。
+- 認証は [app/controllers/concerns/authentication.rb](../../../app/controllers/concerns/authentication.rb) の `Session` ベース。
+- ユーザー認証の主体は [app/models/user.rb](../../../app/models/user.rb) の `has_secure_password`。
+
+## 実装方針
+- `/admin` 配下に `Administrate` を導入する。
+- 認証は既存セッションを流用する。
+- 管理者判定は `users` に明示的なフラグを持たせる案を第一候補とする。
+- 初回の管理対象は `users`、`posts`、`filter_terms` を想定する。
+
+## 手順
+1. `Gemfile` に `gem "administrate"` を追加する。
+2. `make bundle-install` で `Gemfile.lock` を更新する。
+3. `rails generate administrate:install` を Docker 経由で実行する。
+4. `config/routes.rb` の `/admin` 公開対象を必要最小限に絞る。
+5. `Admin::ApplicationController` に認証ガードを実装する。
+6. 管理者フラグ用 migration を追加する。
+7. dashboard の表示項目を整理する。
+8. `/admin` と対象一覧画面を確認する。
+
+## 実装時の論点
+- 管理者権限
+  - `users.admin:boolean` で始めるか。
+- 初回対象
+  - `users`
+  - `posts`
+  - `filter_terms`
+- 後続 Issue に回すもの
+  - 通報審査画面
+  - `sentiment backfill` 実行 action
+  - 強制退会や投稿非表示などの運用 action
+
+## 動作確認
+- 未ログインで `/admin` に入るとログイン画面へ遷移すること
+- 非管理者は `/admin` に入れないこと
+- 管理者だけが `/admin` に入れること
+- 少なくとも1つの管理対象モデルで一覧画面が出ること
+
+## コマンド例
+```bash
+make dev
+make bundle-install
+docker compose --env-file .env.dev -f docker-compose.dev.yml exec -w /app -e HOME=/tmp --user $(id -u):$(id -g) web bundle exec rails generate administrate:install
+make db-migrate
+make test
+```
+
+## 参考
+- ローカル一次情報
+  - [README.md](../../../README.md)
+  - [Gemfile](../../../Gemfile)
+  - [Gemfile.lock](../../../Gemfile.lock)
+  - [Makefile](../../../Makefile)
+  - [docker-compose.dev.yml](../../../docker-compose.dev.yml)
+  - [app/controllers/concerns/authentication.rb](../../../app/controllers/concerns/authentication.rb)
+  - [app/models/user.rb](../../../app/models/user.rb)
+  - [app/models/filter_term.rb](../../../app/models/filter_term.rb)
+  - [2026-03-13-01-admin-gem-comparison.md](./2026-03-13-01-admin-gem-comparison.md)
+- 公式一次ソース
+  - Administrate README: <https://github.com/thoughtbot/administrate>
+  - Administrate Getting Started: <https://administrate-demo.herokuapp.com/getting_started>
+  - Administrate Authentication: <https://administrate-demo.herokuapp.com/authentication>
+  - Administrate Authorization: <https://administrate-demo.herokuapp.com/authorization>


### PR DESCRIPTION
## 概要
- `administrate` gem を追加
- `Gemfile.lock` を更新
- Administrate 導入メモを追加
- `AGENTS.md` に `Gemfile.lock` の取り扱いルールを追記

## 変更内容
- [Gemfile](/home/dcmmw/tone_two/Gemfile) に `gem "administrate"` を追加
- [Gemfile.lock](/home/dcmmw/tone_two/Gemfile.lock) に依存解決結果を反映
- [2026-03-15-01-administrate-introduction-runbook.md](/home/dcmmw/tone_two/docs/03_engineering/admin/2026-03-15-01-administrate-introduction-runbook.md) を追加
- [AGENTS.md](/home/dcmmw/tone_two/AGENTS.md) に `Gemfile.lock` を手編集しない方針を追記

## 補足
- `/admin` の実装は未着手

Related #41
