### PR TITLE
WIP: 管理画面ルートを一時的に非公開化

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,11 @@
 Rails.application.routes.draw do
-  namespace :admin do
-    resources :filter_terms
-    resources :matching_exclusion_terms
-
-    root to: "filter_terms#index"
-  end
+  # 管理画面は一時的に非公開。再開時は下記ルートを戻す。
+  # namespace :admin do
+  #   resources :filter_terms
+  #   resources :matching_exclusion_terms
+  #
+  #   root to: "filter_terms#index"
+  # end
   resource :session, only: %i[new create destroy]
   resource :sign_up, only: %i[new create]
   get "timeline", to: "timeline#index", as: :timeline


### PR DESCRIPTION
## 目的
- セキュリティアラート対応を優先するため、管理画面のルートを閉じてデプロイに載せる

## 変更内容
- `config/routes.rb` の `namespace :admin` をコメントアウト
- 再開時に戻しやすいよう、ルート定義は削除ではなくコメントとして保持

## 確認内容
- `bin/rails routes | rg 'admin'` で `admin` ルートが 0 件であることを確認
- 本番環境でも`/admin` 配下がルーティングされず 404 になるか要確認

## 補足
- 恒久対応としては `Admin::ApplicationController` 側の認証/認可実装が別途必要

Refs #41
