### PR TITLE
chore: loofahを2.25.1へ更新しライセンス一覧を再生成

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.0)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-13 18:06:36 +0900
+最終更新日時: 2026-03-19 20:07:09 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -18,6 +18,7 @@
 | activerecord | 8.1.2 | MIT | https://rubyonrails.org |
 | activestorage | 8.1.2 | MIT | https://rubyonrails.org |
 | activesupport | 8.1.2 | MIT | https://rubyonrails.org |
+| administrate | 1.0.0 | MIT | https://administrate-demo.herokuapp.com/ |
 | base64 | 0.3.0 | Ruby, BSD-2-Clause | https://github.com/ruby/base64 |
 | bcrypt | 3.1.21 | MIT | https://github.com/bcrypt-ruby/bcrypt-ruby |
 | bigdecimal | 4.0.1 | Ruby, BSD-2-Clause | https://github.com/ruby/bigdecimal |
@@ -42,8 +43,12 @@
 | irb | 1.17.0 | Ruby, BSD-2-Clause | https://github.com/ruby/irb |
 | jbuilder | 2.14.1 | MIT | https://github.com/rails/jbuilder |
 | json | 2.18.1 | Ruby | https://github.com/ruby/json |
+| kaminari | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
+| kaminari-actionview | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
+| kaminari-activerecord | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
+| kaminari-core | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
 | logger | 1.7.0 | Ruby, BSD-2-Clause | https://github.com/ruby/logger |
-| loofah | 2.25.0 | MIT | https://github.com/flavorjones/loofah |
+| loofah | 2.25.1 | MIT | https://github.com/flavorjones/loofah |
 | mail | 2.9.0 | MIT | https://github.com/mikel/mail |
 | marcel | 1.1.0 | MIT, Apache-2.0 | https://github.com/rails/marcel |
 | mini_mime | 1.1.5 | MIT | https://github.com/discourse/mini_mime |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-13 18:06:36 +0900
+最終更新日時: 2026-03-19 20:07:09 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -71,6 +71,7 @@
 | activerecord | 8.1.2 | MIT | https://rubyonrails.org |
 | activestorage | 8.1.2 | MIT | https://rubyonrails.org |
 | activesupport | 8.1.2 | MIT | https://rubyonrails.org |
+| administrate | 1.0.0 | MIT | https://administrate-demo.herokuapp.com/ |
 | base64 | 0.3.0 | Ruby, BSD-2-Clause | https://github.com/ruby/base64 |
 | bcrypt | 3.1.21 | MIT | https://github.com/bcrypt-ruby/bcrypt-ruby |
 | bigdecimal | 4.0.1 | Ruby, BSD-2-Clause | https://github.com/ruby/bigdecimal |
@@ -95,8 +96,12 @@
 | irb | 1.17.0 | Ruby, BSD-2-Clause | https://github.com/ruby/irb |
 | jbuilder | 2.14.1 | MIT | https://github.com/rails/jbuilder |
 | json | 2.18.1 | Ruby | https://github.com/ruby/json |
+| kaminari | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
+| kaminari-actionview | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
+| kaminari-activerecord | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
+| kaminari-core | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
 | logger | 1.7.0 | Ruby, BSD-2-Clause | https://github.com/ruby/logger |
-| loofah | 2.25.0 | MIT | https://github.com/flavorjones/loofah |
+| loofah | 2.25.1 | MIT | https://github.com/flavorjones/loofah |
 | mail | 2.9.0 | MIT | https://github.com/mikel/mail |
 | marcel | 1.1.0 | MIT, Apache-2.0 | https://github.com/rails/marcel |
 | mini_mime | 1.1.5 | MIT | https://github.com/discourse/mini_mime |


### PR DESCRIPTION
## 概要
- `loofah 2.25.0` には、`Loofah::HTML5::Scrub.allowed_uri?` が HTML エンティティ入りの `javascript:` URI を不正に許可しうる脆弱性がある
- 例）javascript: をそのまま書かずに、途中を `&#13;` のような HTML エンティティで分断して` java&#13;script:` のように書くと、見た目では分かりづらい形で危険な URI をすり抜ける
- 影響対象は `allowed_uri?` を文字列バリデーション用途で直接使うケースで、修正版は `2.25.1`
- `loofah` は HTML/XML を安全化するサニタイズ用 Gem で、本アプリでも Rails の `sanitize` 経由で利用されている
- Bundler により `loofah` を `2.25.1` へ更新し、ライセンス一覧を再生成

## 変更内容
- Bundler にて `loofah` の適用版を `2.25.1` へ更新
- `docs/80_licenses/gems.md` を再生成
- `docs/80_licenses/licenses_full.md` を再生成

## 背景
- Dependabot alert `Improper detection of disallowed URIs by Loofah allowed_uri?` への対応
- 本アプリでは Rails の `sanitize` 経由で `rails-html-sanitizer` / `loofah` を利用しているため、許容範囲内での依存更新で対応

## 確認内容
- `make test-all`
- `Brakeman`: warning 0
- `importmap audit`: vulnerable packages 0
- Minitest / system test: すべて成功

