### PR TITLE
chore: jsonを2.19.2へ更新しライセンス一覧を再生成

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.18.1)
+    json (2.19.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-19 20:07:09 +0900
+最終更新日時: 2026-03-21 01:48:59 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -42,7 +42,7 @@
 | io-console | 0.8.2 | Ruby, BSD-2-Clause | https://github.com/ruby/io-console |
 | irb | 1.17.0 | Ruby, BSD-2-Clause | https://github.com/ruby/irb |
 | jbuilder | 2.14.1 | MIT | https://github.com/rails/jbuilder |
-| json | 2.18.1 | Ruby | https://github.com/ruby/json |
+| json | 2.19.2 | Ruby | https://github.com/ruby/json |
 | kaminari | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
 | kaminari-actionview | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
 | kaminari-activerecord | 1.2.2 | MIT | https://github.com/kaminari/kaminari |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-19 20:07:09 +0900
+最終更新日時: 2026-03-21 01:48:59 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -95,7 +95,7 @@
 | io-console | 0.8.2 | Ruby, BSD-2-Clause | https://github.com/ruby/io-console |
 | irb | 1.17.0 | Ruby, BSD-2-Clause | https://github.com/ruby/irb |
 | jbuilder | 2.14.1 | MIT | https://github.com/rails/jbuilder |
-| json | 2.18.1 | Ruby | https://github.com/ruby/json |
+| json | 2.19.2 | Ruby | https://github.com/ruby/json |
 | kaminari | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
 | kaminari-actionview | 1.2.2 | MIT | https://github.com/kaminari/kaminari |
 | kaminari-activerecord | 1.2.2 | MIT | https://github.com/kaminari/kaminari |


### PR DESCRIPTION
## 概要

`json` gem を `2.18.1` から `2.19.2` へ更新し、関連するライセンス一覧を再生成しました。

## 変更内容

- `Gemfile.lock` の `json` を `2.19.2` に更新
- `docs/80_licenses/gems.md` を再生成
- `docs/80_licenses/licenses_full.md` を再生成

## 確認内容
- `make test-all` が成功

## 補足
- 今回のアラートは、`json` gem の format string injection 脆弱性への対応
- 主に `JSON.parse(..., allow_duplicate_key: false)` でユーザー入力を処理するケースが影響対象
- 重複キー検出時の内部エラー処理に起因する不具合で、DoS や一部情報漏えいの可能性がある

Closes #236