### PR TITLE
chore: bcryptを3.1.22へ更新しライセンス一覧を再生成

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       kaminari (~> 1.2.2)
     ast (2.4.3)
     base64 (0.3.0)
-    bcrypt (3.1.21)
+    bcrypt (3.1.22)
     bigdecimal (4.0.1)
     bindex (0.8.1)
     bootsnap (1.23.0)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-21 01:48:59 +0900
+最終更新日時: 2026-03-21 02:28:00 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -20,7 +20,7 @@
 | activesupport | 8.1.2 | MIT | https://rubyonrails.org |
 | administrate | 1.0.0 | MIT | https://administrate-demo.herokuapp.com/ |
 | base64 | 0.3.0 | Ruby, BSD-2-Clause | https://github.com/ruby/base64 |
-| bcrypt | 3.1.21 | MIT | https://github.com/bcrypt-ruby/bcrypt-ruby |
+| bcrypt | 3.1.22 | MIT | https://github.com/bcrypt-ruby/bcrypt-ruby |
 | bigdecimal | 4.0.1 | Ruby, BSD-2-Clause | https://github.com/ruby/bigdecimal |
 | bootsnap | 1.23.0 | MIT | https://github.com/rails/bootsnap |
 | builder | 3.3.0 | MIT | https://github.com/rails/builder |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-21 01:48:59 +0900
+最終更新日時: 2026-03-21 02:28:00 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -73,7 +73,7 @@
 | activesupport | 8.1.2 | MIT | https://rubyonrails.org |
 | administrate | 1.0.0 | MIT | https://administrate-demo.herokuapp.com/ |
 | base64 | 0.3.0 | Ruby, BSD-2-Clause | https://github.com/ruby/base64 |
-| bcrypt | 3.1.21 | MIT | https://github.com/bcrypt-ruby/bcrypt-ruby |
+| bcrypt | 3.1.22 | MIT | https://github.com/bcrypt-ruby/bcrypt-ruby |
 | bigdecimal | 4.0.1 | Ruby, BSD-2-Clause | https://github.com/ruby/bigdecimal |
 | bootsnap | 1.23.0 | MIT | https://github.com/rails/bootsnap |
 | builder | 3.3.0 | MIT | https://github.com/rails/builder |


### PR DESCRIPTION
## 概要

`bcrypt` gem を `3.1.21` から `3.1.22` へ更新し、関連するライセンス一覧を再生成しました。

## 変更内容

- `Gemfile.lock` の `bcrypt` を `3.1.22` に更新
- `docs/80_licenses/gems.md` を再生成
- `docs/80_licenses/licenses_full.md` を再生成

## 確認内容

- `make test-all` が成功

## 補足

- 今回のアラートは、JRuby 環境における `bcrypt` の整数オーバーフロー脆弱性への対応（現環境とは無関係）
- `cost=31` のときに鍵強化ループが 0 回になり、想定より弱いハッシュになる可能性がある


Closes #233
