### PR TITLE
chore: commonmarkerを2.7.0へ更新しライセンス文書を再生成

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    commonmarker (2.6.3-x86_64-linux)
+    commonmarker (2.7.0-x86_64-linux)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-26 00:11:06 +0900
+最終更新日時: 2026-03-26 00:33:58 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -25,7 +25,7 @@
 | bootsnap | 1.23.0 | MIT | https://github.com/rails/bootsnap |
 | builder | 3.3.0 | MIT | https://github.com/rails/builder |
 | bundler | 2.4.19 | MIT | https://bundler.io |
-| commonmarker | 2.6.3 | MIT | https://github.com/gjtorikian/commonmarker |
+| commonmarker | 2.7.0 | MIT | https://github.com/gjtorikian/commonmarker |
 | concurrent-ruby | 1.3.6 | MIT | http://www.concurrent-ruby.com |
 | connection_pool | 3.0.2 | MIT | https://github.com/mperham/connection_pool |
 | crass | 1.0.6 | MIT | https://github.com/rgrove/crass/ |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-26 00:11:06 +0900
+最終更新日時: 2026-03-26 00:33:58 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -78,7 +78,7 @@
 | bootsnap | 1.23.0 | MIT | https://github.com/rails/bootsnap |
 | builder | 3.3.0 | MIT | https://github.com/rails/builder |
 | bundler | 2.4.19 | MIT | https://bundler.io |
-| commonmarker | 2.6.3 | MIT | https://github.com/gjtorikian/commonmarker |
+| commonmarker | 2.7.0 | MIT | https://github.com/gjtorikian/commonmarker |
 | concurrent-ruby | 1.3.6 | MIT | http://www.concurrent-ruby.com |
 | connection_pool | 3.0.2 | MIT | https://github.com/mperham/connection_pool |
 | crass | 1.0.6 | MIT | https://github.com/rgrove/crass/ |


### PR DESCRIPTION
## 概要
- `commonmarker` を `2.6.3` から `2.7.0` へ更新
- 依存更新に合わせてライセンス文書を再生成

## 変更内容
- `Gemfile.lock` の `commonmarker` を `2.7.0` に更新
- `docs/80_licenses/gems.md` を再生成
- `docs/80_licenses/licenses_full.md` を再生成

## 確認内容
- `make test-all`
- RuboCop: OK
- Brakeman: OK
- importmap audit: OK
- test / test:system: OK
- ポリシー表示の目視確認: 崩れなし

## 補足
- アプリ内での `commonmarker` 利用は Markdown を HTML に変換する用途に限定
- 公式 `v2.7.0` の主な変更は機能追加中心で、今回の利用形態に直撃する破壊的変更はなし
