### PR TITLE
chore: solid_queueを1.4.0へ更新しライセンス文書を再生成

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
-    solid_queue (1.3.2)
+    solid_queue (1.4.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
       concurrent-ruby (>= 1.3.1)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-26 00:33:58 +0900
+最終更新日時: 2026-03-26 00:53:26 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -85,7 +85,7 @@
 | securerandom | 0.4.1 | Ruby, BSD-2-Clause | https://github.com/ruby/securerandom |
 | solid_cable | 3.0.12 | MIT | https://github.com/rails/solid_cable |
 | solid_cache | 1.0.10 | MIT | http://github.com/rails/solid_cache |
-| solid_queue | 1.3.2 | MIT | https://github.com/rails/solid_queue |
+| solid_queue | 1.4.0 | MIT | https://github.com/rails/solid_queue |
 | stimulus-rails | 1.3.4 | MIT | https://stimulus.hotwired.dev |
 | stringio | 3.2.0 | Ruby, BSD-2-Clause | https://github.com/ruby/stringio |
 | thor | 1.5.0 | MIT | https://github.com/rails/thor |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-03-26 00:33:58 +0900
+最終更新日時: 2026-03-26 00:53:26 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -138,7 +138,7 @@
 | securerandom | 0.4.1 | Ruby, BSD-2-Clause | https://github.com/ruby/securerandom |
 | solid_cable | 3.0.12 | MIT | https://github.com/rails/solid_cable |
 | solid_cache | 1.0.10 | MIT | http://github.com/rails/solid_cache |
-| solid_queue | 1.3.2 | MIT | https://github.com/rails/solid_queue |
+| solid_queue | 1.4.0 | MIT | https://github.com/rails/solid_queue |
 | stimulus-rails | 1.3.4 | MIT | https://stimulus.hotwired.dev |
 | stringio | 3.2.0 | Ruby, BSD-2-Clause | https://github.com/ruby/stringio |
 | thor | 1.5.0 | MIT | https://github.com/rails/thor |


### PR DESCRIPTION
## 概要
- `solid_queue` を `1.3.2` から `1.4.0` へ更新
- 依存更新に合わせてライセンス文書を再生成

## 変更内容
- `Gemfile.lock` の `solid_queue` を `1.4.0` に更新
- `docs/80_licenses/gems.md` を再生成
- `docs/80_licenses/licenses_full.md` を再生成

## 確認内容
- `make test-all`
- RuboCop: OK
- Brakeman: OK
- importmap audit: OK
- test / test:system: OK

## 補足
- 現状このアプリでは `solid_queue` を まだActive Job の実行アダプタとして有効化しておらず、`production` でも `:async` を利用しています
- 公式 `v1.4.0` の主な変更は dynamic recurring tasks サポート追加で、現在の利用形態に直撃する影響は小さい見込みです