### PR TITLE
chore: rack-sessionを2.1.2へ更新しライセンス文書を再生成

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
     rack (3.2.6)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-04-01 16:53:38 +0900
+最終更新日時: 2026-04-15 01:51:26 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -72,7 +72,7 @@
 | racc | 1.8.1 | Ruby, BSD-2-Clause | https://github.com/ruby/racc |
 | rack | 3.2.6 | MIT | https://github.com/rack/rack |
 | rack-attack | 6.8.0 | MIT | https://github.com/rack/rack-attack |
-| rack-session | 2.1.1 | MIT | https://github.com/rack/rack-session |
+| rack-session | 2.1.2 | MIT | https://github.com/rack/rack-session |
 | rack-test | 2.2.0 | MIT | https://github.com/rack/rack-test |
 | rackup | 2.3.1 | MIT | https://github.com/rack/rackup |
 | rails | 8.1.3 | MIT | https://rubyonrails.org |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-04-01 16:53:38 +0900
+最終更新日時: 2026-04-15 01:51:26 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -125,7 +125,7 @@
 | racc | 1.8.1 | Ruby, BSD-2-Clause | https://github.com/ruby/racc |
 | rack | 3.2.6 | MIT | https://github.com/rack/rack |
 | rack-attack | 6.8.0 | MIT | https://github.com/rack/rack-attack |
-| rack-session | 2.1.1 | MIT | https://github.com/rack/rack-session |
+| rack-session | 2.1.2 | MIT | https://github.com/rack/rack-session |
 | rack-test | 2.2.0 | MIT | https://github.com/rack/rack-test |
 | rackup | 2.3.1 | MIT | https://github.com/rack/rackup |
 | rails | 8.1.3 | MIT | https://rubyonrails.org |


### PR DESCRIPTION
## 目的
- Dependabot alertの対象である`rack-session`を脆弱バージョンから更新する

## 結論
- `rack-session`を`2.1.1`から`2.1.2`へ更新した
- 依存更新にあわせてライセンス文書を再生成した

## 変更点
- `Gemfile.lock`の`rack-session`を`2.1.2`へ更新
- `docs/80_licenses/gems.md`の最終更新日時と`rack-session`バージョン表記を更新
- `docs/80_licenses/licenses_full.md`の最終更新日時と`rack-session`バージョン表記を更新

## 動作確認
- `make test-all` を実行し成功
- `security-privacy-check`観点で`git diff --staged`を確認し、P0/P1/P2の検出なし

## 関連Issue
Closes #262
