### PR TITLE
chore: commonmarkerを2.8.1へ更新しライセンス文書を更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    commonmarker (2.7.0-x86_64-linux)
+    commonmarker (2.8.1-x86_64-linux)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-04-23 16:22:11 +0900
+最終更新日時: 2026-04-23 16:44:52 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -25,7 +25,7 @@
 | bootsnap | 1.23.0 | MIT | https://github.com/rails/bootsnap |
 | builder | 3.3.0 | MIT | https://github.com/rails/builder |
 | bundler | 2.4.19 | MIT | https://bundler.io |
-| commonmarker | 2.7.0 | MIT | https://github.com/gjtorikian/commonmarker |
+| commonmarker | 2.8.1 | MIT | https://github.com/gjtorikian/commonmarker |
 | concurrent-ruby | 1.3.6 | MIT | http://www.concurrent-ruby.com |
 | connection_pool | 3.0.2 | MIT | https://github.com/mperham/connection_pool |
 | crass | 1.0.6 | MIT | https://github.com/rgrove/crass/ |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-04-23 16:22:11 +0900
+最終更新日時: 2026-04-23 16:44:52 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -78,7 +78,7 @@
 | bootsnap | 1.23.0 | MIT | https://github.com/rails/bootsnap |
 | builder | 3.3.0 | MIT | https://github.com/rails/builder |
 | bundler | 2.4.19 | MIT | https://bundler.io |
-| commonmarker | 2.7.0 | MIT | https://github.com/gjtorikian/commonmarker |
+| commonmarker | 2.8.1 | MIT | https://github.com/gjtorikian/commonmarker |
 | concurrent-ruby | 1.3.6 | MIT | http://www.concurrent-ruby.com |
 | connection_pool | 3.0.2 | MIT | https://github.com/mperham/connection_pool |
 | crass | 1.0.6 | MIT | https://github.com/rgrove/crass/ |


### PR DESCRIPTION
## 目的
- commonmarker の依存更新を反映し、ライセンス文書の記載を最新化する

## 変更点
- `Gemfile.lock` の `commonmarker` バージョン更新
- `docs/80_licenses/gems.md` の `commonmarker` 表記更新と最終更新日時更新
- `docs/80_licenses/licenses_full.md` の `commonmarker` 表記更新と最終更新日時更新

## 動作確認
- `make test-all` を実行し、`rubocop` `brakeman` `importmap audit` `test` `test:system` がすべて成功

## 関連Issue
Closes #270
