### PR TITLE
chore: pumaを8.0.0へ更新しRender向けのIPv4待受設定と運用ドキュメントを反映

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.0)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,8 +27,9 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+# Specifies the `port` and host that Puma will listen on to receive requests.
+# Render の運用前提に合わせて IPv4 bind を明示する。
+port ENV.fetch("PORT", 3000), "0.0.0.0"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/docs/04_operations/deploy/2026-04-23-01-puma8-ipv4-ipv6-impact-note.md
+++ b/docs/04_operations/deploy/2026-04-23-01-puma8-ipv4-ipv6-impact-note.md
@@ -1,0 +1,80 @@
+# Puma 8 更新時の IPv4/IPv6 影響メモ（初学者向け）
+
+## 目的
+- `puma 7.2.0 -> 8.0.0` で、なぜ「本番影響がありうる」のかを短く説明できる状態にする。
+- 特に `Render` 運用での `IPv4/IPv6` 論点を、初学者でも判断しやすい形で残す。
+
+## まず結論
+- このアプリでは、`Render` 上の本番でも `Puma` を使っている。
+- `Puma 8` ではデフォルト bind が `IPv6` 側へ寄るため、`config/puma.rb` で待ち受け先を明示しないと環境依存の差が出る可能性がある。
+- 現時点の運用方針としては、`0.0.0.0`（IPv4）を明示するのが安全。
+
+## 役割分担（超要約）
+- `Rails`: アプリ本体（画面遷移、業務ロジック）
+- `Puma`: HTTPリクエストを受けて Rails に渡すアプリサーバ
+- `Render`: Puma + Rails を動かす実行環境（PaaS）
+
+つまり「Render を使っているから Puma は無関係」ではない。Render から渡された通信を受けるのは Puma。
+
+## このリポジトリで確認できる事実（ローカル一次情報）
+- 本番起動コマンドは `bundle exec puma -C config/puma.rb`
+  - [Dockerfile](../../../Dockerfile)
+- エントリポイントでも `puma` 起動を前提に `db:prepare` を実行している
+  - [bin/docker-entrypoint](../../../bin/docker-entrypoint)
+- `config/puma.rb` は `port` 指定のみで、host/bind の明示がない
+  - [config/puma.rb](../../../config/puma.rb)
+- 開発環境は `bin/rails server -b 0.0.0.0 -p 3000` を明示している
+  - [docker-compose.dev.yml](../../../docker-compose.dev.yml)
+
+## どこが変更点か（公式一次情報）
+- Puma 8 の Upgrade Guide に、デフォルト bind 挙動の変更が記載されている。
+  - <https://github.com/puma/puma/blob/main/docs/8.0-Upgrade.md>
+- リリースノート
+  - <https://github.com/puma/puma/releases/tag/v8.0.0>
+
+## Render の文脈で何が問題になるか
+Render 公式ドキュメントでは、Web Service は `0.0.0.0` に bind して待ち受ける前提で説明されている。
+
+- Render が受けたリクエストをアプリへ転送する
+- Puma がその受け口で待っていないと接続失敗になる
+
+参考: <https://render.com/docs/web-services>
+
+## 初学者向けイメージ
+1. ブラウザが `https://...` にアクセスする
+2. Render が受け取る
+3. Render がコンテナ内の Puma に渡す
+4. Puma が受け取って Rails に処理を渡す
+
+このとき、Render が渡す入口と Puma の待受がズレると失敗する。
+
+## IPv6を使う/使わないの判断
+### IPv6寄り（Puma 8 デフォルト寄り）
+- メリット: デフォルト挙動に沿える。
+- デメリット: 環境依存の差を踏みやすく、運用確認コストが上がる。
+
+### IPv4固定（`0.0.0.0` 明示）
+- メリット: Render の説明と一致し、挙動が読みやすい。
+- メリット: 開発環境の待受設定とも整合しやすい。
+- デメリット: 将来 IPv6 方針を採る場合は見直しが必要。
+
+## このアプリでの推奨
+- Puma 8 を採用する場合は、`config/puma.rb` で待受を明示する。
+- まずは `0.0.0.0` 明示で安全側に寄せ、デプロイ直後に `/up` と主要画面の疎通を確認する。
+
+## 今回の採用方針（2026-04-23）
+- 本アプリでは当面 `IPv4` 待受を採用する。
+- 待受の固定は Dockerfile ではなく Puma 設定で行う。
+- 具体的には [config/puma.rb](../../../config/puma.rb) の `port` 設定を以下にする。
+
+```ruby
+port ENV.fetch("PORT", 3000), "0.0.0.0"
+```
+
+## 反映状況
+- 2026-04-23 時点で [config/puma.rb](../../../config/puma.rb) に上記設定を反映済み。
+
+## 関連ドキュメント
+- [Issue 194: Kamal proxy と Thruster の構成比較と採用方針](./2026-03-11-01-issue-194-kamal-proxy-vs-thruster-decision.md)
+- [Deploy runbook](./00_deploy_runbook.md)
+- [Issue #74 死活監視（Render Health Check）実施手順](../monitoring/2026-02-08-01-render-health-check-issue-74-runbook.md)

--- a/docs/80_licenses/gems.md
+++ b/docs/80_licenses/gems.md
@@ -2,7 +2,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-04-23 16:44:52 +0900
+最終更新日時: 2026-04-23 17:38:51 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -67,7 +67,7 @@
 | prism | 1.9.0 | MIT | https://github.com/ruby/prism |
 | propshaft | 1.3.1 | MIT | https://github.com/rails/propshaft |
 | psych | 5.3.1 | MIT | https://github.com/ruby/psych |
-| puma | 7.2.0 | BSD-3-Clause | https://puma.io |
+| puma | 8.0.0 | BSD-3-Clause | https://puma.io |
 | raabro | 1.4.0 | MIT | https://github.com/floraison/raabro |
 | racc | 1.8.1 | Ruby, BSD-2-Clause | https://github.com/ruby/racc |
 | rack | 3.2.6 | MIT | https://github.com/rack/rack |

--- a/docs/80_licenses/licenses_full.md
+++ b/docs/80_licenses/licenses_full.md
@@ -55,7 +55,7 @@
 
 各gemのライセンス本文および著作権表示は、ホームページ列のリンク先リポジトリにてご確認いただけます。
 
-最終更新日時: 2026-04-23 16:44:52 +0900
+最終更新日時: 2026-04-23 17:38:51 +0900
 
 | Gem | Version | License | Homepage |
 |---|---:|---|---|
@@ -120,7 +120,7 @@
 | prism | 1.9.0 | MIT | https://github.com/ruby/prism |
 | propshaft | 1.3.1 | MIT | https://github.com/rails/propshaft |
 | psych | 5.3.1 | MIT | https://github.com/ruby/psych |
-| puma | 7.2.0 | BSD-3-Clause | https://puma.io |
+| puma | 8.0.0 | BSD-3-Clause | https://puma.io |
 | raabro | 1.4.0 | MIT | https://github.com/floraison/raabro |
 | racc | 1.8.1 | Ruby, BSD-2-Clause | https://github.com/ruby/racc |
 | rack | 3.2.6 | MIT | https://github.com/rack/rack |


### PR DESCRIPTION
## 目的
- Puma 8 への更新を実施し、Render 本番での待受挙動を安定化する。
- IPv4/IPv6 論点と運用方針をドキュメント化する。
- 依存更新に合わせてライセンス一覧を更新する。

## 結論
- `puma` を `7.2.0` から `8.0.0` へ更新した。
- `config/puma.rb` で `port ENV.fetch("PORT", 3000), "0.0.0.0"` を明示し、Render 運用前提に合わせた。
- 運用判断メモを追加し、ライセンスドキュメントを更新した。

## 変更点
- `Gemfile.lock`
  - `puma (7.2.0)` -> `puma (8.0.0)`
- `config/puma.rb`
  - Puma の待受 host を `0.0.0.0` で明示
- `docs/04_operations/deploy/2026-04-23-01-puma8-ipv4-ipv6-impact-note.md`
  - Puma 8 更新時の IPv4/IPv6 影響と採用方針を記録
- `docs/80_licenses/gems.md`
- `docs/80_licenses/licenses_full.md`
  - 依存更新後のライセンス情報を更新

## 動作確認
- [x] `make test` を実行し、テストが全件成功することを確認
- [x] 依存更新後に起動確認（開発環境）
- [x] デプロイ後に `/up` が 200 を返すこと
- [x] 主要画面（ログイン/タイムラインなど）の疎通確認
- [x] Render のログで Puma 起動エラーがないこと

## 参考資料（1次ソース）
- https://github.com/puma/puma/releases/tag/v8.0.0
- https://github.com/puma/puma/blob/main/docs/8.0-Upgrade.md
- https://render.com/docs/web-services

## 関連Issue
Closes #263
